### PR TITLE
Ouya support

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -73,6 +73,13 @@ fullscreen = 1
 # not yet merged features.
 #android.branch = master
 
+# (str) OUYA Console category. Should be one of GAME or APP
+# If you leave this blank, OUYA support will not be enabled
+#android.ouya.category = GAME
+
+# (str) Filename of OUYA Console icon. It must be a 732x412 png image.
+#android.ouya.icon.filename = %(source.dir)s/data/ouya_icon.png
+
 #
 # iOS specific
 #

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -386,6 +386,16 @@ class TargetAndroid(Target):
         if icon:
             build_cmd += ' --icon {}'.format(join(self.buildozer.root_dir, icon))
 
+        # OUYA Console support
+        ouya_category = config.getdefault('app', 'android.ouya.category', '').upper()
+        if ouya_category:
+            if ouya_category not in ('GAME', 'APP'):
+                raise SystemError('Invalid android.ouya.category: "{}" must be one of GAME or APP'.format(ouya_category))
+            # add icon
+            build_cmd += ' --ouya-category {}'.format(ouya_category)
+            ouya_icon = config.getdefault('app', 'android.ouya.icon.filename', '')
+            build_cmd += ' --ouya-icon {}'.format(join(self.buildozer.root_dir, ouya_icon))
+
         # add orientation
         orientation = config.getdefault('app', 'orientation', 'landscape')
         if orientation == 'all':


### PR DESCRIPTION
Adds two new configuration options to buildozer.spec

android.ouya.category
android.ouya.icon.filename

This feature relies on matching support in python-for-android, so there is no point to merging this pull request until after https://github.com/kivy/python-for-android/pull/119 has been reviewed and merged
