### PR TITLE
android.add_jars config option

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -69,6 +69,12 @@ fullscreen = 1
 # (str) Android entry point, default is ok for Kivy-based app
 #android.entrypoint = org.renpy.android.PythonActivity
 
+# (str) Semicolon separated list of Java .jar files to add to the libs so
+# that pyjnius can access their classes. Don't add jars that you do not need,
+# since extra jars can slow down the build process. Allows wildcards matching,
+# for example: OUYA-ODK/libs/*.jar
+#android.add_jars = foo.jar;bar.jar;path/to/more/*.jar
+
 # (str) python-for-android branch to use, if not master, useful to try
 # not yet merged features.
 #android.branch = master

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -22,6 +22,7 @@ from buildozer.target import Target
 from os import environ
 from os.path import join, realpath, expanduser
 from shutil import copyfile
+from glob import glob
 
 
 class TargetAndroid(Target):
@@ -374,6 +375,18 @@ class TargetAndroid(Target):
                 'android.permissions', [])
         for permission in permissions:
             build_cmd += ' --permission {0}'.format(permission)
+
+        # add extra Java jar files
+        add_jars = config.getdefault('app', 'android.add_jars', '')
+        if add_jars:
+            for pattern in add_jars.split(';'):
+                pattern = expanduser(pattern.strip())
+                matches = glob(pattern)
+                if matches:
+                    for jar in matches:
+                        build_cmd += ' --add-jar "{}"'.format(jar)
+                else:
+                    raise SystemError("Failed to find jar file: {}".format(pattern))
 
         # add presplash
         presplash = config.getdefault('app', 'presplash.filename', '')


### PR DESCRIPTION
This adds an android.add_jars config option to buildozer.spec

it is a semicolon-separated list of jar filenames (with wildcard support) that will be included inside the apk bundle's libs directory, making their classes available to pyjnius.

This is a wrapper around the --add-jar command line option for python-for-android's build.py script from pull request https://github.com/kivy/python-for-android/pull/120 so naturally, there is no point in merging this one until after that PR has been considered :)
