### PR TITLE
make sure android.branch works with fresh clone

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -69,7 +69,7 @@ class TargetAndroid(Target):
         version = self.buildozer.config.getdefault(
                 'app', 'android.ndk', self.android_ndk_version)
         return join(self.buildozer.global_platform_dir,
-                'android-ndk-{0}'.format(version))
+                'android-ndk-r{0}'.format(version))
 
     @property
     def apache_ant_dir(self):
@@ -301,10 +301,10 @@ class TargetAndroid(Target):
             cmd('git clean -dxf', cwd=pa_dir)
             cmd('git pull origin master', cwd=pa_dir)
 
-            source = self.buildozer.config.getdefault('app', 'android.branch')
-            if source:
-                cmd('git checkout --track -b %s origin/%s' % (source, source),
-                    cwd=pa_dir)
+        source = self.buildozer.config.getdefault('app', 'android.branch')
+        if source:
+            cmd('git checkout  %s' % (source),
+                cwd=pa_dir)
 
         self._install_apache_ant()
         self._install_android_sdk()


### PR DESCRIPTION
Was not working with fresh clone before and had issue with name of ndk `9` wasn't related to `r9` and it kept re-downloading the ndk.
