### PR TITLE
Check for package name starting with number

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -300,13 +300,13 @@ class Buildozer(object):
         adderror = errors.append
         if not get('app', 'title', ''):
             adderror('[app] "title" is missing')
-        if not get('app', 'package.name', ''):
-            adderror('[app] "package.name" is missing')
         if not get('app', 'source.dir', ''):
             adderror('[app] "source.dir" is missing')
             
         package_name = get('app', 'package.name', '')
-        if package_name[0] in map(str, range(10)):
+        if not package_name:
+            adderror('[app] "package.name" is missing')
+        elif package_name[0] in map(str, range(10)):
             adderror('[app] "package.name" may not start with a number.')
 
         version = get('app', 'version', '')


### PR DESCRIPTION
As discussed on the kivy mailing list, this pr adds a check for package names starting with a number, which is not allowed in android.

This would fix #64 .
