### PR TITLE
Add 'bin' to suggested default directory excludes

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -19,7 +19,7 @@ source.include_exts = py,png,jpg,kv,atlas
 #source.exclude_exts = spec
 
 # (list) List of directory to exclude (let empty to not exclude anything)
-#source.exclude_dirs = tests
+#source.exclude_dirs = tests, bin
 
 # (list) List of exclusions using pattern matching
 #source.exclude_patterns = license,images/*/*.jpg


### PR DESCRIPTION
Prevent situations where you could accidentally package apks in apks in apks...
