### PR TITLE
Changed timeout to 600s to avoid premature end for android tools install

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -297,7 +297,7 @@ class TargetAndroid(Target):
             self.android_cmd, packages,
             cwd=self.buildozer.global_platform_dir))
         while True:
-            index = child.expect([EOF, '[y/n]: '])
+            index = child.expect([EOF, '\[y/n\]:'], timeout=600)
             if index == 0:
                 break
             child.sendline('y')


### PR DESCRIPTION
Android tools install takes more than 30s (pexpect default) to download and finish. I changed the timeout to 5 minutes, but that may also be insufficient for people on a slow connection or slow computer. We might consider setting it to None for infinite timeout.
