### PR TITLE
Fix #115

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -312,7 +312,8 @@ class TargetAndroid(Target):
         # 3 pass installation.
         need_refresh = False
 
-        self.buildozer.cmd('chmod ug+x {}'.format(self.android_cmd))
+        if not os.access(self.android_cmd, os.X_OK):
+            self.buildozer.cmd('chmod ug+x {}'.format(self.android_cmd))
 
         # 1. update the tool and platform-tools if needed
         packages = self._android_list_sdk()


### PR DESCRIPTION
Avoid blind chmod on android_cmd

Check for the missing exec bit before attempting to change it instead
