### PR TITLE
resolve unnecessary download issue #137

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -318,7 +318,7 @@ class TargetAndroid(Target):
 
     def _read_version_subdir(self, *args):
         try:
-            versions = [ _process_version_string(v) for v in os.listdir(join(*args))]
+            versions = [ self._process_version_string(v) for v in os.listdir(join(*args))]
             versions.sort()
             return versions[-1]
         except:
@@ -332,7 +332,7 @@ class TargetAndroid(Target):
         for p in packages:
             if p.startswith(key):
                 version_string = p.split(key)[-1]
-                version = _process_version_string(version_string)                
+                version = self._process_version_string(version_string)                
                 package_versions.append(version)
         if not package_versions:
             return


### PR DESCRIPTION
Found some issues in the way version compare was being performed.

Issue 1. _find_latest_package() included the "key" in the resulting versions list.
    ver = "build-tools-20.0.0"
    v_build_tools = "20.0.0"
    ver > v_build_tools
    --> True

Issue 2. String comparison is being performed.
    It appears to have worked ok so far, but strings do not evaulate like numbers.

```
v4_2_2 = "4.2.2"
v4_2_16 = "4.2.16"
v4_2_2 > v4_2_16
--> True

Updated code to parse version_string to list of ints, for example "4.2.2" --> [4,2,2]
Note this implementation assumes versions are the same length.
```
