### PR TITLE
Fix for android.library_references path issue

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -636,7 +636,7 @@ class TargetAndroid(Target):
                 self.buildozer.error('Invalid library reference (path not found): {}'.format(cref))
                 exit(1)
             # get a relative path from the project file
-            ref = relpath(ref, dist_dir)
+            ref = relpath(ref, realpath(dist_dir))
             # ensure the reference exists
             references.append(ref)
 


### PR DESCRIPTION
Here is a fix for a path issue when android.p4a_dir is defined (it is not using the default one downloaded by buildozer) and entries in android.library_references use relative paths from source.dir
