### PR TITLE
Test in file_rename if target directory exists.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -553,6 +553,8 @@ class Buildozer(object):
             source = join(cwd, source)
             target = join(cwd, target)
         self.debug('Rename {0} to {1}'.format(source, target))
+        if not os.path.isdir(os.path.dirname(target)):
+            self.error('Rename {0} to {1} fails becaues {2} is not a directory'.format(source, target, os.path.directory(target)))
         rename(source, target)
 
     def file_copy(self, source, target, cwd=None):


### PR DESCRIPTION
This is an attempt to give a reasonable error message in cases where
we are about to crash.  In particular, when android.sdk_path has a
path that does not exist, buildozer should provide a hint as to what
might have gone wrong.

Note that his also relates to issue #4 which is how I figured out what was going wrong.
