### PR TITLE
Set "UTF-8" to java file.encoding for android update command explicitly

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -301,10 +301,12 @@ class TargetAndroid(Target):
 
     def _android_update_sdk(self, packages):
         from buildozer.libs.pexpect import EOF
+        java_tool_options = environ.get('JAVA_TOOL_OPTIONS', '')
         child = self.buildozer.cmd_expect('{} update sdk -u -a -t {}'.format(
             self.android_cmd, packages,
             cwd=self.buildozer.global_platform_dir),
-            timeout=None)
+            timeout=None,
+            env={'JAVA_TOOL_OPTIONS': java_tool_options + ' -Dfile.encoding=UTF-8'})
         while True:
             index = child.expect([EOF, '[y/n]: '])
             if index == 0:


### PR DESCRIPTION
Hi.

In current version Bulldozer, I have failed to run command "buildozer android debug".
I examined from output exception, and found the next thing.
- Current(2014/10/25) Android-sdk license is included Non-ASCII characters.
- There is an environment that is not used UTF-8 to default file.encoding for java (ex: Mac OS in Japanese).
- In this environment, Android command do output license as Non-UTF8. And Then, Buildozer fail to output characters and raise exception "UnicodeDecodeError".

So I try to fix it.

attakei
