### PR TITLE
Fixed logic to compare with “non installed” with “minor version upped" 

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -323,7 +323,6 @@ class TargetAndroid(Target):
         versions = []
         for v in os.listdir(join(*args)):
             try:
-                print(os.listdir(join(*args)))
                 versions.append(self._process_version_string(v))
             except:
                 pass


### PR DESCRIPTION
In verifying #155, I have failed to install build-tool another reasons.
So, I try to fix it. (These and #155 are independent of each other.)

Issue 1: When packaging begin from a fresh clone of buildozer, it is always failed to check latest version of build-tool.
Current logic:
  v_build_tools = '0'
  ver = [1, 2, 3]
  '0' > [1, 2, 3]
  --> False, do not run install build-tool.

Fixed:
  v_build_tools = [0]
  ver = [1, 2, 3]
  [0] > [1, 2, 3]
  --> True, do not run install build-tool.

Issue 2: wrong args for _android_update_sdk()
Method expects string as arg, but passed with list.
Fix to pass package name based from version list, for example ver=[1,2,3'] --> arg='build-tool-1.2.3'.

attakei
