### PR TITLE
fix build error and allow redirecting build folder

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -125,6 +125,7 @@ class Buildozer(object):
                 'buildozer', 'log_level', '1'))
         except:
             pass
+        self.builddir = self.config.getdefault('buildozer', 'builddir', None)
 
         self.targetname = None
         self.target = None
@@ -404,6 +405,9 @@ class Buildozer(object):
 
         # create local dir
         specdir = dirname(self.specfilename)
+        if self.builddir:
+            specdir = self.builddir
+
         self.mkdir(join(specdir, '.buildozer'))
         self.mkdir(join(specdir, 'bin'))
         self.mkdir(self.applibs_dir)
@@ -788,6 +792,8 @@ class Buildozer(object):
 
     @property
     def buildozer_dir(self):
+        if self.builddir:
+            return join(self.builddir, '.buildozer')
         return join(self.root_dir, '.buildozer')
 
     @property

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -323,6 +323,10 @@ class TargetAndroid(Target):
 
     def _read_version_subdir(self, *args):
         versions = []
+        if not os.path.exists(join(*args)):
+            self.buildozer.debug(
+                'build-tools folder not found {}'.format(join(*args)))
+            return [0]
         for v in os.listdir(join(*args)):
             try:
                 versions.append(self._process_version_string(v))


### PR DESCRIPTION
fixes #161 checks if build-tools exists and returns if it does not so it can be fetched
fixes #162 set builddir in you spec file so the packages are created outside your project
builddir = /tmp/buildozer/  # for example
