### PR TITLE
ensure whitelist always has a list

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -494,7 +494,7 @@ class TargetAndroid(Target):
         return package.lower()
 
     def _generate_whitelist(self, dist_dir):
-        p4a_whitelist = self.buildozer.config.getlist('app', 'android.p4a_whitelist')
+        p4a_whitelist = self.buildozer.config.getlist('app', 'android.p4a_whitelist') or []
         whitelist_fn = join(dist_dir, 'whitelist.txt')
         with open(whitelist_fn, 'w') as fd:
             for wl in p4a_whitelist:


### PR DESCRIPTION
Should fix this bug:
````
# Package the application
# project.properties updated
Traceback (most recent call last):
  File "/usr/local/bin/buildozer", line 9, in <module>
    load_entry_point('buildozer==0.25', 'console_scripts', 'buildozer')()
  File "/usr/local/lib/python2.7/dist-packages/buildozer/scripts/client.py", line 13, in main
    Buildozer().run_command(sys.argv[1:])
  File "/usr/local/lib/python2.7/dist-packages/buildozer/__init__.py", line 967, in run_command
    self.target.run_commands(args)
  File "/usr/local/lib/python2.7/dist-packages/buildozer/target.py", line 85, in run_commands
    func(args)
  File "/usr/local/lib/python2.7/dist-packages/buildozer/target.py", line 97, in cmd_debug
    self.buildozer.build()
  File "/usr/local/lib/python2.7/dist-packages/buildozer/__init__.py", line 194, in build
    self.target.build_package()
  File "/usr/local/lib/python2.7/dist-packages/buildozer/targets/android.py", line 535, in build_package
    self._generate_whitelist(dist_dir)
  File "/usr/local/lib/python2.7/dist-packages/buildozer/targets/android.py", line 500, in _generate_whitelist
    for wl in p4a_whitelist:
TypeError: 'NoneType' object is not iterable
````

Though if the more appropriate fix is to make `getlist` always return a list, then just close this. :)