### PR TITLE
allow custom source folders in buildozer.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -35,6 +35,10 @@ version.filename = %(source.dir)s/main.py
 # comma seperated e.g. requirements = sqlite3,kivy
 requirements = kivy
 
+# (str) Custom source folders for requirements
+# Sets custom source for any requirements with recipes
+# requirements.source.kivy = ../../kivy
+
 # (list) Garden requirements
 #garden_requirements =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -464,6 +464,17 @@ class TargetAndroid(Target):
         if not exists(dist_dir):
             need_compile = 1
 
+        source_dirs = {'P4A_{}_DIR'.format(name[20:]):
+                           realpath(expanduser(value))
+                       for name, value in self.buildozer.config.items('app')
+                       if name.startswith('requirements.source.')}
+        if source_dirs:
+            need_compile = 1
+            self.buildozer.environ.update(source_dirs)
+            self.buildozer.info('Using custom source dirs:\n    {}'.format(
+                '\n    '.join(['{} = {}'.format(k, v)
+                             for k, v in source_dirs.items()])))
+
         if not need_compile:
             self.buildozer.info('Distribution already compiled, pass.')
             return

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -464,6 +464,7 @@ class TargetAndroid(Target):
         if not exists(dist_dir):
             need_compile = 1
 
+        # len('requirements.source.') == 20, so use name[20:]
         source_dirs = {'P4A_{}_DIR'.format(name[20:]):
                            realpath(expanduser(value))
                        for name, value in self.buildozer.config.items('app')

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -9,7 +9,7 @@ if sys.platform != 'darwin':
 import plistlib
 from buildozer import BuildozerCommandException
 from buildozer.target import Target, no_config
-from os.path import join, basename
+from os.path import join, basename, expanduser, realpath
 from getpass import getpass
 
 PHP_TEMPLATE = '''
@@ -127,6 +127,17 @@ class TargetIos(Target):
         need_compile = 0
         if last_requirements != ios_requirements:
             need_compile = 1
+
+        source_dirs = {'{}_DIR'.format(name[20:]):
+                            realpath(expanduser(value))
+                       for name, value in self.buildozer.config.items('app')
+                       if name.startswith('requirements.source.')}
+        if source_dirs:
+            need_compile = 1
+            self.buildozer.environ.update(source_dirs)
+            self.buildozer.info('Using custom source dirs:\n    {}'.format(
+                '\n    '.join(['{} = {}'.format(k, v)
+                               for k, v in source_dirs.items()])))
 
         if not need_compile:
             self.buildozer.info('Distribution already compiled, pass.')

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -128,7 +128,8 @@ class TargetIos(Target):
         if last_requirements != ios_requirements:
             need_compile = 1
 
-        source_dirs = {'{}_DIR'.format(name[20:]):
+        # len('requirements.source.') == 20, so use name[20:]
+        source_dirs = {'{}_DIR'.format(name[20:].upper()):
                             realpath(expanduser(value))
                        for name, value in self.buildozer.config.items('app')
                        if name.startswith('requirements.source.')}


### PR DESCRIPTION
Allows you to specify custom folders to use when building recipes:

    requirements.source.kivy = ../../kivy

This will set `P4A_kivy_DIR` for the Android target and `kivy_DIR` for the iOS target. The iOS portion is completely untested, as I don't have a Mac or an iOS device.