### PR TITLE
check for complete dist instead of dist dir

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -461,7 +461,9 @@ class TargetAndroid(Target):
 
         dist_name = self.buildozer.config.get('app', 'package.name')
         dist_dir = join(self.pa_dir, 'dist', dist_name)
-        if not exists(dist_dir):
+        dist_file = join(dist_dir, 'private', 'include', 'python2.7',
+                         'pyconfig.h')
+        if not exists(dist_file):
             need_compile = 1
 
         # len('requirements.source.') == 20, so use name[20:]


### PR DESCRIPTION
This checks for the last file copied into the dist in p4a. It would be best if p4a actually created a specific file to tell that the dist is complete, but that could break compatibility. It might be best to make p4a do that when Buildozer is updated to support @inclement's Python build script.