### PR TITLE
Fixed bug where an Android package ending with -preview caused an error.

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -341,9 +341,12 @@ class TargetAndroid(Target):
         for p in packages:
             if not p.startswith(key):
                 continue
-            version_string = p.split(key)[-1]
-            version = parse(version_string)
-            package_versions.append(version)
+            try:
+                version_string = p.split(key)[-1]
+                version = parse(version_string)
+                package_versions.append(version)
+            except ValueError:
+                pass
         if not package_versions:
             return
         return max(package_versions)


### PR DESCRIPTION
Today's Android package manifests caused a ValueError exception where one of the packages ended with -preview and int() was called on it.
This will cause buildozer to ignore that package.