### PR TITLE
Added support for downloading and handling android ndk r10 versions. Fixes #229 and #227

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -596,6 +596,12 @@ class Buildozer(object):
             self.cmd('tar xjf {0}'.format(archive), cwd=cwd)
             return
 
+        if archive.endswith('.bin'):
+            # To process the bin files for linux and darwin systems
+            self.cmd('chmod a+x {0}'.format(archive),cwd=cwd)
+            self.cmd('./{0}'.format(archive),cwd=cwd)
+            return
+
         if archive.endswith('.zip'):
             archive = join(cwd, archive)
             zf = zipfile.ZipFile(archive)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -256,17 +256,28 @@ class TargetAndroid(Target):
             self.buildozer.info('Android NDK found at {0}'.format(ndk_dir))
             return ndk_dir
 
+        import re
+        _version = re.search('(.+?)[a-z]', self.android_ndk_version).group(1)
+        
         self.buildozer.info('Android NDK is missing, downloading')
         if platform in ('win32', 'cygwin'):
             # Checking of 32/64 bits at Windows from: http://stackoverflow.com/a/1405971/798575
             import struct
             archive = 'android-ndk-r{0}-windows-{1}.zip'
             is_64 = (8*struct.calcsize("P") == 64)
+
         elif platform in ('darwin', ):
-            archive = 'android-ndk-r{0}-darwin-{1}.tar.bz2'
+            if int(_version) > 9:
+                archive = 'android-ndk-r{0}-darwin-{1}.bin'
+            else:
+                archive = 'android-ndk-r{0}-darwin-{1}.tar.bz2'
             is_64 = (os.uname()[4] == 'x86_64')
+
         elif platform.startswith('linux'):
-            archive = 'android-ndk-r{0}-linux-{1}.tar.bz2'
+            if int(_version) > 9: # if greater than 9, take it as .bin file
+                archive = 'android-ndk-r{0}-linux-{1}.bin'
+            else:
+                archive = 'android-ndk-r{0}-linux-{1}.tar.bz2'
             is_64 = (os.uname()[4] == 'x86_64')
         else:
             raise SystemError('Unsupported platform: {0}'.format(platform))


### PR DESCRIPTION
@akshayaurora  Here are the changes made:
* android ndk r10 versions are only avalable in ".bin" format.
* Modified the _install_android_ndk function in /buildozer/targets/android.py.
  - Checks the version of ndk given in the spec file, whether its greater than 9. 
    If it is greater than 9, generate the link containing the .bin url.
* Modified the file_extract function in /buildozer/__init__.py
  - Introduced the functionality to handle .bin files.