### PR TITLE
Fixed Space in app path issue. Fixes #13

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -548,7 +548,7 @@ class TargetAndroid(Target):
             '{python} build.py --name {name}'
             ' --version {version}'
             ' --package {package}'
-            ' --{storage_type} {appdir}'
+            ' --{storage_type} "{appdir}"'
             ' --sdk {androidsdk}'
             ' --minsdk {androidminsdk}').format(
             python=executable,


### PR DESCRIPTION
The issue is that if there is a space in the application path. The application build step fails.
This fix resolves the application path and solves the issue.