### PR TITLE
Changed p4a download to pull old_toolchain branch

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -413,7 +413,8 @@ class TargetAndroid(Target):
                 cmd('ln -sf {} ./python-for-android'.format(system_p4a_dir),
                     cwd = self.buildozer.platform_dir)
             else:
-                cmd('git clone -b old_toolchain --single-branch https://github.com/kivy/python-for-android.git',
+                cmd('git clone -b old_toolchain --single-branch '
+                    'https://github.com/kivy/python-for-android.git',
                     cwd=self.buildozer.platform_dir)
         elif self.platform_update:
             cmd('git clean -dxf', cwd=pa_dir)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -413,7 +413,7 @@ class TargetAndroid(Target):
                 cmd('ln -sf {} ./python-for-android'.format(system_p4a_dir),
                     cwd = self.buildozer.platform_dir)
             else:
-                cmd('git clone https://github.com/kivy/python-for-android',
+                cmd('git clone -b old_toolchain --single-branch https://github.com/kivy/python-for-android.git',
                     cwd=self.buildozer.platform_dir)
         elif self.platform_update:
             cmd('git clean -dxf', cwd=pa_dir)


### PR DESCRIPTION
This should only be merged at exactly the same time that the p4a revamp is changed to the master branch, with the old p4a toolchain kept in a new old_toolchain branch.

It should be followed immediately by releasing a new version of buildozer on pypi.