### PR TITLE
update installation info

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,6 +17,17 @@ If you target Android, you must install at least Cython, few build libs, and a
 Java SDK. Some binaries of the Android SDK are still in 32 bits, so you need
 few 32bits libraries available::
 
+Android on Ubuntu 15.10 (64bit)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    sudo pip install --upgrade cython==0.21
+    sudo dpkg --add-architecture i386
+    sudo apt-get update
+    sudo apt-get install build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386 
+
+
 Android on Ubuntu 14.10 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -25,7 +36,7 @@ Android on Ubuntu 14.10 (64bit)
     sudo pip install --upgrade cython==0.21
     sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install build-essential ccache git lib32stdc++6 lib32z1 lib32z1-dev python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev
+    sudo apt-get install build-essential ccache git lib32stdc++6 lib32z1 lib32z1-dev python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386
 
 Android on Ubuntu 13.10 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,7 +46,7 @@ Android on Ubuntu 13.10 (64bit)
     sudo pip install --upgrade cython==0.21
     sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install build-essential ccache git ia32-libs libncurses5:i386 libstdc++6:i386 python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386
+    sudo apt-get install build-essential ccache git lib32z1 lib32bz2-1.0 libncurses5:i386 libstdc++6:i386 python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386
 
 Android on Ubuntu 12.04 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,4 +54,4 @@ Android on Ubuntu 12.04 (64bit)
 ::
 
     sudo pip install --upgrade cython==0.21
-    sudo apt-get install build-essential ccache git ia32-libs python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev
+    sudo apt-get install build-essential ccache git lib32z1 lib32bz2-1.0 libncurses5:i386 libstdc++6:i386 python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386


### PR DESCRIPTION
Updated the installation info. 
Adding "Android on Ubuntu 15.10  (64bit)" : Tested in my laptop.
Adding `zlib1g:i386` as this package includes debugging symbols for use when debugging applications which use zlib.
I hope everything is correct.