### PR TITLE
Implement source.include_patterns

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -698,6 +698,9 @@ class Buildozer(object):
         exclude_exts = self.config.getlist('app', 'source.exclude_exts', '')
         exclude_dirs = self.config.getlist('app', 'source.exclude_dirs', '')
         exclude_patterns = self.config.getlist('app', 'source.exclude_patterns', '')
+        include_patterns = self.config.getlist('app',
+                                               'source.include_patterns',
+                                               '')
         app_dir = self.app_dir
 
         self.debug('Copy application source from {}'.format(source_dir))
@@ -724,14 +727,19 @@ class Buildozer(object):
                     if filtered_root.startswith(exclude_dir):
                         is_excluded = True
                         break
-                if is_excluded:
-                    continue
 
                 # pattern matching
-                for pattern in exclude_patterns:
+                if not is_excluded:
+                    # match pattern if not ruled out by exclude_dirs
+                    for pattern in exclude_patterns:
+                        if fnmatch(filtered_root, pattern):
+                            is_excluded = True
+                            break
+                for pattern in include_patterns:
                     if fnmatch(filtered_root, pattern):
-                        is_excluded = True
+                        is_excluded = False
                         break
+
                 if is_excluded:
                     continue
 
@@ -740,7 +748,7 @@ class Buildozer(object):
                 if fn.startswith('.'):
                     continue
 
-                # exclusion by pattern matching
+                # pattern matching
                 is_excluded = False
                 dfn = fn.lower()
                 if filtered_root:
@@ -748,6 +756,10 @@ class Buildozer(object):
                 for pattern in exclude_patterns:
                     if fnmatch(dfn, pattern):
                         is_excluded = True
+                        break
+                for pattern in include_patterns:
+                    if fnmatch(dfn, pattern):
+                        is_excluded = False
                         break
                 if is_excluded:
                     continue

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -15,6 +15,9 @@ source.dir = .
 # (list) Source files to include (let empty to include all the files)
 source.include_exts = py,png,jpg,kv,atlas
 
+# (list) List of inclusions using pattern matching
+#source.include_patterns = assets/*,images/*.png
+
 # (list) Source files to exclude (let empty to not exclude anything)
 #source.exclude_exts = spec
 


### PR DESCRIPTION
As per #245 and #30 

Matches files and folders with a list of include patterns similar to exlude_patterns functioning

Priority of include_patterns is above exclude_patterns/exclude_dirs, and below include_exts/exclude_exts

I haven't tested this because I am facing some problems setting up buildozer. 