### PR TITLE
put bin/ in builddir if specified in buildozer.spec

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -130,6 +130,7 @@ class Buildozer(object):
         except:
             pass
         self.builddir = self.config.getdefault('buildozer', 'builddir', None)
+        self.bin_apk_dir = self.config.getdefault('buildozer', 'bin_dir', None)
 
         self.targetname = None
         self.target = None
@@ -417,17 +418,18 @@ class Buildozer(object):
         self.mkdir(self.global_buildozer_dir)
         self.mkdir(self.global_cache_dir)
 
-        # create local dir
-        specdir = dirname(self.specfilename)
-        if self.builddir:
-            specdir = self.builddir
+        # create local .buildozer/ dir
+        self.mkdir(self.buildozer_dir)
+        # create local bin/ dir
+        self.mkdir(self.bin_dir)
 
-        self.mkdir(join(specdir, '.buildozer'))
-        self.mkdir(join(specdir, 'bin'))
         self.mkdir(self.applibs_dir)
         self.state = JsonStore(join(self.buildozer_dir, 'state.db'))
 
         if self.targetname:
+            specdir = dirname(self.specfilename)
+            if self.builddir:
+                specdir = self.builddir
             target = self.targetname
             self.mkdir(join(self.global_platform_dir, target, 'platform'))
             self.mkdir(join(specdir, '.buildozer', target, 'platform'))
@@ -818,8 +820,8 @@ class Buildozer(object):
 
     @property
     def bin_dir(self):
-        if self.builddir:
-            return join(self.builddir, 'bin')
+        if self.bin_apk_dir:
+            return join(self.bin_apk_dir, 'bin')
         return join(self.root_dir, 'bin')
 
     @property

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -821,7 +821,7 @@ class Buildozer(object):
     @property
     def bin_dir(self):
         if self.bin_apk_dir:
-            return join(self.bin_apk_dir, 'bin')
+            return self.bin_apk_dir
         return join(self.root_dir, 'bin')
 
     @property

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -818,6 +818,8 @@ class Buildozer(object):
 
     @property
     def bin_dir(self):
+        if self.builddir:
+            return join(self.builddir, 'bin')
         return join(self.root_dir, 'bin')
 
     @property


### PR DESCRIPTION
I prefer to keep generated (thus reproducable) things outside of my project folder. Thus, I added this to my `buildozer.spec` file (example):

```
[buildozer]
builddir = /home/jabba/.kivy_builddirs/kivy_project
```

Now, if I launch `buildozer android debug deploy run`, the local folder `.buildozer` is created in this specified builddir instead of the project's folder. However, `bin/` is still created in the project's folder, littering it with a big `.apk` file.

My patch does the following: if builddir is specified (as seen above), then `bin/` (similarly to `.buildozer/`) will be created in the builddir. This way the project folder has the source files and things necessary for the build process are nicely separated.

Rationale: I keep my projects in my Dropbox folder and I like to keep their sizes to the minimum. Build stuff should go somewhere else.