### PR TITLE
Remove pip --download-cache flag (fixes #279)

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -469,10 +469,9 @@ class Buildozer(object):
         self.cmd('curl http://python-distribute.org/distribute_setup.py | venv/bin/python', get_stdout=True, cwd=self.buildozer_dir)
 
         self.debug('Install requirement {} in virtualenv'.format(module))
-        self.cmd('pip install --download-cache={} --target={} {}'.format(
-                self.global_cache_dir, self.applibs_dir, module),
-                env=self.env_venv,
-                cwd=self.buildozer_dir)
+        self.cmd('pip install --target={} {}'.format(self.applibs_dir, module),
+                 env=self.env_venv,
+                 cwd=self.buildozer_dir)
 
     def check_garden_requirements(self):
         '''Ensure required garden packages are available to be included.


### PR DESCRIPTION
From the pip changelog:
>pip install --download-cache and pip wheel --download-cache command line flags have been deprecated and the functionality removed. Since pip now automatically configures and uses it's internal HTTP cache which supplants the --download-cache the existing options have been made non functional but will still be accepted until their removal in pip v8.0. For more information please see https://pip.pypa.io/en/stable/reference/pip_install.html#caching