### PR TITLE
Ugly hack to fix wrong data being used for target Android API in new …

### DIFF
--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -59,7 +59,9 @@ class TargetAndroidNew(TargetAndroid):
                 continue
             elif option == "--sdk":
                 cmd.append("--android_api")
-                cmd.extend(values)
+                values = list(values)
+                values[0] = self.buildozer.config.getdefault('app', 'android.api', self.android_api)
+                cmd.extend(tuple(values))
             else:
                 cmd.extend(args)
 


### PR DESCRIPTION
…toolchain

The old toolchain passes only the SDK version, which is *not* the same as the target API. This attempts to correct the problem, but should probably be correctly dealt with once the new toolchain becomes the default one.