### PR TITLE
Fix issues with android.p4a_dir spec file property

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -459,8 +459,8 @@ class TargetAndroid(Target):
         cmd = self.buildozer.cmd
         self.pa_dir = pa_dir = join(self.buildozer.platform_dir,
                                     self.p4a_directory)
-        system_p4a_dir = self.buildozer.config.getdefault('app',
-                                                          'android.p4a_dir')
+        system_p4a_dir = expanduser(self.buildozer.config.getdefault('app',
+                                                          'android.p4a_dir'))
         if system_p4a_dir:
             self.pa_dir = pa_dir = system_p4a_dir
             if not self.buildozer.file_exists(pa_dir):

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -464,8 +464,10 @@ class TargetAndroid(Target):
         if system_p4a_dir:
             self.pa_dir = pa_dir = system_p4a_dir
             if not self.buildozer.file_exists(pa_dir):
-                self.buildozer.critical(
-                    'Path for android.p4a_dir doesnt exists')
+                self.buildozer.error(
+                    'Path for android.p4a_dir does not exist')
+                self.buildozer.error('')
+                raise BuildozerException()
         else:
             if not self.buildozer.file_exists(pa_dir):
                 cmd(


### PR DESCRIPTION
- `android.py` uses non-existing `critical()` method when `android.p4a_dir` doesn't exist
- interpret tilde (~) for $HOME in `android.p4a_dir`, also makes consistent with `android.ndk_path`, etc.