### PR TITLE
Add spec option to skip automated update of installed android package

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -101,6 +101,11 @@ fullscreen = 1
 # (list) python-for-android whitelist
 #android.p4a_whitelist =
 
+# (bool) If True, then skip trying to update the Android sdk
+# This can be useful to avoid excess Internet downloads or save time
+# when an update is due and you just want to test/build your package
+# android.skip_update = False
+
 # (str) Android entry point, default is ok for Kivy-based app
 #android.entrypoint = org.renpy.android.PythonActivity
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -401,8 +401,13 @@ class TargetAndroid(Target):
 
         # 1. update the tool and platform-tools if needed
         packages = self._android_list_sdk()
+        skip_upd = self.buildozer.config.getdefault('app',
+                                                    'android.skip_update', False)
         if 'tools' in packages or 'platform-tools' in packages:
-            self._android_update_sdk('tools,platform-tools')
+            if not skip_upd:
+                self._android_update_sdk('tools,platform-tools')
+            else:
+                self.buildozer.info('Skipping Android SDK update due to spec file setting')
 
         # 2. install the latest build tool
         v_build_tools = self._read_version_subdir(self.android_sdk_dir,


### PR DESCRIPTION
This patch adds an option to the spec file that lets you disable automated updates of the android sdk for a given project.

Now you can add `android.skip_updates = True` and the build command will skip the call that decides to download updates to Android SDK components.

I was in the middle of a project when the `buildozer android debug deploy` command decided it wanted to download an update to Android SDK 24 even though I didn't need it, and I didn't want to wait an hour for it to come down. So I added this option to fix that.

Note, I think this is different to issue #267 which wants to disable all possible Internet checks; my patch may fix that but at this point I don't know what other tasks may be referencing the Internet...