### PR TITLE
use ios-deploy version 1.7.0

### DIFF
--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -102,7 +102,7 @@ class TargetIos(Target):
         self.ios_deploy_dir = ios_deploy_dir = join(self.buildozer.platform_dir,
                 'ios-deploy')
         if not self.buildozer.file_exists(ios_deploy_dir):
-            cmd('git clone https://github.com/phonegap/ios-deploy',
+            cmd('git clone --branch 1.7.0 https://github.com/phonegap/ios-deploy',
                     cwd=self.buildozer.platform_dir)
 
     def get_available_packages(self):


### PR DESCRIPTION
buildozer fails with
````
Command failed: make ios-deploy
````
This happens because ios-deploy changed their project structure after version 1.7.0. This issue shows again that we should always use releases of other projects instead of the master branch.