### PR TITLE
add adb and p4a commands to android/android_new

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -52,8 +52,13 @@ class Target(object):
 
         result = []
         last_command = []
-        for arg in args:
-            if not arg.startswith('--'):
+        while args:
+            arg = args.pop(0)
+            if arg == '--':
+                if last_command:
+                    last_command += args
+                    break
+            elif not arg.startswith('--'):
                 if last_command:
                     result.append(last_command)
                     last_command = []

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -840,10 +840,15 @@ class TargetAndroid(Target):
 
     def cmd_adb(self, *args):
         self.check_requirements()
-        print('To set up ADB in this shell session, execute:')
-        print('    alias adb=$(buildozer {} adb 2>&1 >/dev/null)'
-              .format(self.targetname))
-        sys.stderr.write(self.adb_cmd + '\n')
+        self.install_platform()
+        args = args[0]
+        if args and args[0] == '--alias':
+            print('To set up ADB in this shell session, execute:')
+            print('    alias adb=$(buildozer {} adb --alias 2>&1 >/dev/null)'
+                  .format(self.targetname))
+            sys.stderr.write(self.adb_cmd + '\n')
+        else:
+            self.buildozer.cmd(' '.join([self.adb_cmd] + args))
 
     def cmd_deploy(self, *args):
         super(TargetAndroid, self).cmd_deploy(*args)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -34,6 +34,7 @@ from buildozer.libs.version import parse
 
 
 class TargetAndroid(Target):
+    targetname = 'android'
     p4a_branch = "old_toolchain"
     p4a_directory = "python-for-android"
     p4a_apk_cmd = "python build.py"
@@ -836,6 +837,13 @@ class TargetAndroid(Target):
             serials.append(serial.split()[0])
         self._serials = serials
         return serials
+
+    def cmd_adb(self, *args):
+        self.check_requirements()
+        print('To set up ADB in this shell session, execute:')
+        print('    alias adb=$(buildozer {} adb 2>&1 >/dev/null)'
+              .format(self.targetname))
+        sys.stderr.write(self.adb_cmd + '\n')
 
     def cmd_deploy(self, *args):
         super(TargetAndroid, self).cmd_deploy(*args)

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -8,6 +8,7 @@ from os.path import join, expanduser, realpath
 
 
 class TargetAndroidNew(TargetAndroid):
+    targetname = 'android_new'
     p4a_branch = "master"
     p4a_directory = "python-for-android-master"
     p4a_apk_cmd = "apk --bootstrap=sdl2"

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -2,6 +2,7 @@
 '''
 Android target, based on python-for-android project (new toolchain)
 '''
+import sys
 
 from buildozer.targets.android import TargetAndroid
 from os.path import join, expanduser, realpath
@@ -103,6 +104,18 @@ class TargetAndroidNew(TargetAndroid):
         if not entrypoint:
             self.buildozer.config.set('app', 'android.entrypoint',  'org.kivy.android.PythonActivity')
         return super(TargetAndroidNew, self).cmd_run(*args)
+
+    def cmd_p4a(self, *args):
+        self.check_requirements()
+        self.install_platform()
+        args = args[0]
+        if args and args[0] == '--alias':
+            print('To set up p4a in this shell session, execute:')
+            print('    alias p4a=$(buildozer {} p4a --alias 2>&1 >/dev/null)'
+                  .format(self.targetname))
+            sys.stderr.write('PYTHONPATH={} {}\n'.format(self.pa_dir, self._p4a_cmd))
+        else:
+            self._p4a(' '.join(*args))
 
 
 def get_target(buildozer):

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -115,7 +115,7 @@ class TargetAndroidNew(TargetAndroid):
                   .format(self.targetname))
             sys.stderr.write('PYTHONPATH={} {}\n'.format(self.pa_dir, self._p4a_cmd))
         else:
-            self._p4a(' '.join(*args))
+            self._p4a(' '.join(args) if args else '')
 
 
 def get_target(buildozer):


### PR DESCRIPTION
NOTE: requires changes in #323 

Adds adb and p4a commands to buildozer. Arguments must follow `--`, i.e.
`buildozer android_new adb -- devices`

Also provides a handy method of creating an alias to run these commands:
`buildozer android_new adb --alias`
````
# Check configuration tokens
# Ensure build layout
# Check configuration tokens
# Search for Git (git)
#  -> found at /usr/bin/git
# Search for Cython (cython)
#  -> found at /usr/local/bin/cython
# Search for Java compiler (javac)
#  -> found at /System/Library/Frameworks/JavaVM.framework/Versions/A/Commands/javac
# Search for Java keytool (keytool)
#  -> found at /System/Library/Frameworks/JavaVM.framework/Versions/A/Commands/keytool
To set up ADB in this shell session, execute:
    alias adb=$(buildozer android_new adb --alias 2>&1 >/dev/null)
/Users/kived/.buildozer/android/platform/android-sdk-20/platform-tools/adb
````