### PR TITLE
throw error early if running in venv

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -461,6 +461,14 @@ class Buildozer(object):
         requirements = [x for x in requirements if onlyname(x) not in
                 target_available_packages]
 
+        if requirements and hasattr(sys, 'real_prefix'):
+            e = self.error
+            e('virtualenv is needed to install pure-Python modules, but')
+            e('virtualenv does not support nesting, and you are running')
+            e('buildozer in one. Please run buildozer outside of a')
+            e('virtualenv instead.')
+            exit(1)
+
         # did we already installed the libs ?
         if exists(self.applibs_dir) and \
             self.state.get('cache.applibs', '') == requirements:


### PR DESCRIPTION
```
(venv) ryan@ryan-mk3:~/g/t/bztest$ buildozer android debug
# Check configuration tokens
# Ensure build layout
# Check configuration tokens
# Preparing build
# Check requirements for android
# Install platform
# Apache ANT found at /home/ryan/.buildozer/android/platform/apache-ant-1.9.4
# Android SDK found at /home/ryan/.buildozer/android/platform/android-sdk-20
# Android NDK found at /home/ryan/.buildozer/android/platform/android-ndk-r9c
# Check application requirements
# virtualenv is needed to install pure-Python modules, but
# virtualenv does not support nesting, and you are running
# buildozer in one. Please run buildozer outside of a
# virtualenv instead.
```