### PR TITLE
Update installation.rst (Ubuntu16.04)

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,6 +17,16 @@ If you target Android, you must install at least Cython, few build libs, and a
 Java SDK. Some binaries of the Android SDK are still in 32 bits, so you need
 few 32bits libraries available::
 
+Android on Ubuntu 16.04 (64bit)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    sudo pip install --upgrade cython==0.21
+    sudo dpkg --add-architecture i386
+    sudo apt-get update
+    sudo apt-get install build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python2.7-dev openjdk-8-jdk unzip zlib1g-dev zlib1g:i386 
+
 Android on Ubuntu 15.10 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -26,7 +36,6 @@ Android on Ubuntu 15.10 (64bit)
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python2.7-dev openjdk-7-jdk unzip zlib1g-dev zlib1g:i386 
-
 
 Android on Ubuntu 14.10 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
openjdk-8-jdk instead of 7 since 7 has "no installation candidate" on Ubuntu16.04.

Other than that it's the same installation commands as Ubuntu15. If i remember correctly this was the only thing i changed from the Ubuntu15 commands, and now my app works normally on androids and is published. 

Just to be sure, i made again a virtual environment with python2.7 and installed everything up to running `buildozer init`. If you want me to test it fully (that is, build a new app and run it on my android to make sure no extra libs are needed) let me know.
