### PR TITLE
Added p4a.local_recipes to default.spec and handled its absence

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -101,6 +101,9 @@ fullscreen = 1
 # (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
 #android.p4a_dir =
 
+# (str) The directory in which python-for-android should look for your own build recipes (if any)
+#p4a.local_recipes = 
+
 # (list) python-for-android whitelist
 #android.p4a_whitelist =
 

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -73,7 +73,7 @@ class TargetAndroidNew(TargetAndroid):
         return join(self._build_dir, 'dists', dist_name)
 
     def get_local_recipes_dir(self):
-        local_recipes = self.buildozer.config.get('app', 'p4a.local_recipes')
+        local_recipes = self.buildozer.config.getdefault('app', 'p4a.local_recipes')
         return realpath(expanduser(local_recipes)) if local_recipes else None
 
     def execute_build_package(self, build_cmd):


### PR DESCRIPTION
This both adds the token in default.spec (although not set by default), and uses the appropriate method to handle when it isn't defined.

This needs testing, my buildozer isn't set up to run right now.