### PR TITLE
Fix file_matches to never return None

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -582,8 +582,6 @@ class Buildozer(object):
         result = []
         for pattern in patterns:
             matches = glob(expanduser(pattern.strip()))
-            if not matches:
-                return
             result.extend(matches)
         return result
 


### PR DESCRIPTION
Should fix https://github.com/kivy/buildozer/issues/431 , as the deleted code just makes the function return None when presumably an empty list is fine and it should just continue.

Making a PR rather than a straight change in case I'm missing something about what's intended here.