### PR TITLE
spec file: use portrait orientation by default

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -52,7 +52,7 @@ requirements = kivy
 #icon.filename = %(source.dir)s/data/icon.png
 
 # (str) Supported orientation (one of landscape, portrait or all)
-orientation = landscape
+orientation = portrait
 
 # (list) List of service to declare
 #services = NAME:ENTRYPOINT_TO_PY,NAME2:ENTRYPOINT2_TO_PY


### PR DESCRIPTION
99% of apps are portrait oriented, only advanced games are using landscape by default, p4a should follow