### PR TITLE
spec file: dont use fullscreen by default

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -69,7 +69,7 @@ orientation = landscape
 #
 
 # (bool) Indicate if the application should be fullscreen or not
-fullscreen = 1
+fullscreen = 0
 
 # (list) Permissions
 #android.permissions = INTERNET


### PR DESCRIPTION
Most of the Android apps are not fullscreen, statusbar is visible. Default should follow that rule. Only games/navigations are fullscreen by default. This setting makes new users think Kivy is meant only for games, or p4a cant produce app with normal, statusbar visible UI.