### PR TITLE
Fix Py3 Incompatable str + bytes issue.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -788,7 +788,10 @@ class Buildozer(object):
                   '"..", "_applibs")] + sys.path\n')
         with open(main_py, 'rb') as fd:
             data = fd.read()
-        data = header + data
+        if IS_PY3:
+            data = bytes(header, 'utf8') + data
+        else:
+            data = header + data
         with open(main_py, 'wb') as fd:
             fd.write(data)
         self.info('Patched service/main.py to include applibs')


### PR DESCRIPTION
Found while using buildozer with py3 on old-toolchain as $ buildozer android debug