### PR TITLE
android_new: add "android.arch" config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.idea
 
 # Installer logs
 pip-log.txt

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -168,7 +168,7 @@ fullscreen = 1
 # (bool) Copy library instead of making a libpymodules.so
 #android.copy_libs = 1
 
-# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
+# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86
 android.arch = armeabi-v7a
 
 #

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -168,6 +168,9 @@ fullscreen = 1
 # (bool) Copy library instead of making a libpymodules.so
 #android.copy_libs = 1
 
+# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
+android.arch = armeabi-v7a
+
 #
 # iOS specific
 #

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -1,11 +1,12 @@
 from sys import exit
 
+
 def no_config(f):
     f.__no_config = True
     return f
 
-class Target(object):
 
+class Target(object):
     def __init__(self, buildozer):
         super(Target, self).__init__()
         self.buildozer = buildozer

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -19,7 +19,7 @@ class TargetAndroidNew(TargetAndroid):
     def __init__(self, buildozer):
         super(TargetAndroidNew, self).__init__(buildozer)
         self._build_dir = join(self.buildozer.platform_dir, 'build')
-        self._p4a_cmd = ('python -m pythonforandroid.toolchain ')
+        self._p4a_cmd = 'python -m pythonforandroid.toolchain '
         self._p4a_bootstrap = self.buildozer.config.getdefault(
             'app', 'android.bootstrap', 'sdl2')
         self.p4a_apk_cmd += self._p4a_bootstrap
@@ -66,8 +66,9 @@ class TargetAndroidNew(TargetAndroid):
             options.append('--local-recipes')
             options.append(local_recipes)
         available_modules = self._p4a(
-            "create --dist_name={} --bootstrap={} --requirements={} --arch armeabi-v7a {}".format(
-                 dist_name, self._p4a_bootstrap, requirements, " ".join(options)),
+            "create --dist_name={} --bootstrap={} --requirements={} --arch {} {}".format(
+                 dist_name, self._p4a_bootstrap, requirements,
+                 self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"), " ".join(options)),
             get_stdout=True)[0]
 
     def get_dist_dir(self, dist_name):
@@ -121,6 +122,9 @@ class TargetAndroidNew(TargetAndroid):
         if blacklist_src:
             cmd.append('--blacklist')
             cmd.append(realpath(blacklist_src))
+
+        cmd.append('--arch')
+        cmd.append(self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"))
 
         cmd = " ".join(cmd)
         self._p4a(cmd)


### PR DESCRIPTION
Allow choosing the arch to build for

Usage for arm64:
```
android.arch = arm64-v8a
```
