### PR TITLE
android_new: add 'symlink-java-src' option

### DIFF
--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -66,9 +66,10 @@ class TargetAndroidNew(TargetAndroid):
             options.append('--local-recipes')
             options.append(local_recipes)
         available_modules = self._p4a(
-            "create --dist_name={} --bootstrap={} --requirements={} --arch {} {}".format(
+            "create --dist_name={} --bootstrap={} --requirements={} --arch={} --symlink-java-src={} {}".format(
                  dist_name, self._p4a_bootstrap, requirements,
-                 self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"), " ".join(options)),
+                 self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"),
+                 self.buildozer.config.getdefault('app', 'android.symlink-java-src', False), " ".join(options)),
             get_stdout=True)[0]
 
     def get_dist_dir(self, dist_name):
@@ -123,8 +124,10 @@ class TargetAndroidNew(TargetAndroid):
             cmd.append('--blacklist')
             cmd.append(realpath(blacklist_src))
 
-        cmd.append('--arch')
-        cmd.append(self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"))
+        cmd.append('--arch={}'.format(self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a")))
+
+        cmd.append('--symlink-java-src={}'.format(
+            self.buildozer.config.getdefault('app', 'android.symlink-java-src', False)))
 
         cmd = " ".join(cmd)
         self._p4a(cmd)

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -66,7 +66,7 @@ class TargetAndroidNew(TargetAndroid):
             options.append('--local-recipes')
             options.append(local_recipes)
         available_modules = self._p4a(
-            "create --dist_name={} --bootstrap={} --requirements={} --arch={} --symlink-java-src={} {}".format(
+            "create --dist_name={} --bootstrap={} --requirements={} --arch={} --symlink-java-src {} {}".format(
                  dist_name, self._p4a_bootstrap, requirements,
                  self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a"),
                  self.buildozer.config.getdefault('app', 'android.symlink-java-src', False), " ".join(options)),
@@ -125,9 +125,6 @@ class TargetAndroidNew(TargetAndroid):
             cmd.append(realpath(blacklist_src))
 
         cmd.append('--arch={}'.format(self.buildozer.config.getdefault('app', 'android.arch', "armeabi-v7a")))
-
-        cmd.append('--symlink-java-src={}'.format(
-            self.buildozer.config.getdefault('app', 'android.symlink-java-src', False)))
 
         cmd = " ".join(cmd)
         self._p4a(cmd)


### PR DESCRIPTION
Adds ability to set the p4a 'symlink-java-src' option.

Don't know how useful this actually is, but I plan to use it, so I might as well make a PR