### PR TITLE
android_new: change skip_update to skip all updates

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -415,19 +415,17 @@ class TargetAndroid(Target):
                                                   'build-tools')
         packages = self._android_list_sdk(include_all=True)
         ver = self._find_latest_package(packages, 'build-tools-')
-        if ver and ver > v_build_tools:
-            self._android_update_sdk(self._build_package_string('build-tools',
-                                                                ver))
+        if ver and ver > v_build_tools and not skip_upd:
+            self._android_update_sdk(self._build_package_string('build-tools', ver))
         # 2.bis check aidl can be runned
         self._check_aidl(v_build_tools)
 
         # 3. finally, install the android for the current api
-        android_platform = join(self.android_sdk_dir, 'platforms',
-                                'android-{0}'.format(self.android_api))
+        android_platform = join(self.android_sdk_dir, 'platforms', 'android-{0}'.format(self.android_api))
         if not self.buildozer.file_exists(android_platform):
             packages = self._android_list_sdk()
             android_package = 'android-{}'.format(self.android_api)
-            if android_package in packages:
+            if android_package in packages and not skip_upd:
                 self._android_update_sdk(android_package)
 
         self.buildozer.info('Android packages installation done.')


### PR DESCRIPTION
In current master. android.skip_updates only skips updating platform-tools and tools, and will still update the build-tools. This is a problem for me at least, because Buildozer will auto update my build tools from 19.1.0, and 19.1.0 is the only version I can get to build correctly.

This is just a quick fix so that it will do no updates with the option enabled