### PR TITLE
Added missing release term

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -751,7 +751,7 @@ class TargetAndroid(Target):
             mode = 'debug'
         else:
             build_cmd += [("release", )]
-            mode = 'release'
+            mode = 'release-unsigned'
 
         self.execute_build_package(build_cmd)
 


### PR DESCRIPTION
References #469.

Fixes the followign error when we build:
'''
Traceback (most recent call last):
  File "/usr/local/bin/buildozer", line 11, in <module>
    load_entry_point('buildozer', 'console_scripts', 'buildozer')()
  File "/home/fruitbat/Repos/buildozer/buildozer/scripts/client.py", line 13, in main
    Buildozer().run_command(sys.argv[1:])
  File "/home/fruitbat/Repos/buildozer/buildozer/__init__.py", line 1026, in run_command
    self.target.run_commands(args)
  File "/home/fruitbat/Repos/buildozer/buildozer/target.py", line 91, in run_commands
    func(args)
  File "/home/fruitbat/Repos/buildozer/buildozer/target.py", line 108, in cmd_release
    self.buildozer.build()
  File "/home/fruitbat/Repos/buildozer/buildozer/__init__.py", line 211, in build
    self.target.build_package()
  File "/home/fruitbat/Repos/buildozer/buildozer/targets/android.py", line 778, in build_package
    copyfile(join(dist_dir, 'bin', apk), join(self.buildozer.bin_dir, apk))
  File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: u'/home/fruitbat/Repos/kivy-speedtest/.buildozer/android/platform/python-for-android/dist/xxx.com/bin/xzzz-release.apk'

'''