### PR TITLE
android / android_new: Work towards Windows builds

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -137,7 +137,7 @@ class TargetAndroid(Target):
         checkbin('Java compiler (javac)', self.javac_cmd)
         checkbin('Java keytool (keytool)', self.keytool_cmd)
 
-    def check_configuration_tokens(self):
+    def check_configuration_tokens(self, **kwargs):
         errors = []
 
         # check the permission
@@ -242,9 +242,7 @@ class TargetAndroid(Target):
 
         archive = archive.format(self.android_sdk_version)
         url = 'http://dl.google.com/android/'
-        self.buildozer.download(url,
-                                archive,
-                                cwd=self.buildozer.global_platform_dir)
+        self.buildozer.download(url, archive, cwd=self.buildozer.global_platform_dir)
 
         self.buildozer.info('Unpacking Android SDK')
         self.buildozer.file_extract(archive, cwd=self.buildozer.global_platform_dir)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -7,30 +7,31 @@ Android target, based on python-for-android project (old toolchain)
 # project!
 #
 
+import io
+import os
 import sys
-if sys.platform == 'win32':
-    raise NotImplementedError('Windows platform not yet working for Android')
+import traceback
+from glob import glob
+from os import environ
+from os.path import exists, join, realpath, expanduser, basename, relpath
+from pipes import quote
+from shutil import copyfile
+from sys import platform
+
+from buildozer import BuildozerException
+from buildozer import IS_PY3
+from buildozer.libs.version import parse
+from buildozer.target import Target
+
+if sys.platform in ('win32', 'cygwin'):
+    # raise NotImplementedError('Windows platform not yet working for Android')
+    pass
 
 ANDROID_API = '19'
 ANDROID_MINAPI = '9'
 ANDROID_SDK_VERSION = '20'
 ANDROID_NDK_VERSION = '9c'
 APACHE_ANT_VERSION = '1.9.4'
-
-import traceback
-import os
-import io
-from pipes import quote
-from sys import platform, executable
-from buildozer import BuildozerException
-from buildozer import IS_PY3
-from buildozer.target import Target
-from os import environ
-from os.path import exists, join, realpath, expanduser, basename, relpath
-from shutil import copyfile
-from glob import glob
-
-from buildozer.libs.version import parse
 
 
 class TargetAndroid(Target):
@@ -41,70 +42,71 @@ class TargetAndroid(Target):
 
     @property
     def android_sdk_version(self):
-        return self.buildozer.config.getdefault('app', 'android.sdk',
-                                                ANDROID_SDK_VERSION)
+        return self.buildozer.config.getdefault('app', 'android.sdk', ANDROID_SDK_VERSION)
 
     @property
     def android_ndk_version(self):
-        return self.buildozer.config.getdefault('app', 'android.ndk',
-                                                ANDROID_NDK_VERSION)
+        return self.buildozer.config.getdefault('app', 'android.ndk', ANDROID_NDK_VERSION)
 
     @property
     def android_api(self):
-        return self.buildozer.config.getdefault('app', 'android.api',
-                                                ANDROID_API)
+        return self.buildozer.config.getdefault('app', 'android.api', ANDROID_API)
 
     @property
     def android_minapi(self):
-        return self.buildozer.config.getdefault('app', 'android.minapi',
-                                                ANDROID_MINAPI)
+        return self.buildozer.config.getdefault('app', 'android.minapi', ANDROID_MINAPI)
 
     @property
     def android_sdk_dir(self):
-        directory = expanduser(self.buildozer.config.getdefault(
-            'app', 'android.sdk_path', ''))
+        directory = expanduser(self.buildozer.config.getdefault('app', 'android.sdk_path', ''))
         if directory:
             return realpath(directory)
-        version = self.buildozer.config.getdefault('app', 'android.sdk',
-                                                   self.android_sdk_version)
-        return join(self.buildozer.global_platform_dir,
-                    'android-sdk-{0}'.format(version))
+        version = self.buildozer.config.getdefault('app', 'android.sdk', self.android_sdk_version)
+        return join(self.buildozer.global_platform_dir, 'android-sdk-{0}'.format(version))
 
     @property
     def android_ndk_dir(self):
-        directory = expanduser(self.buildozer.config.getdefault(
-            'app', 'android.ndk_path', ''))
+        directory = expanduser(self.buildozer.config.getdefault('app', 'android.ndk_path', ''))
         if directory:
             return realpath(directory)
-        version = self.buildozer.config.getdefault('app', 'android.ndk',
-                                                   self.android_ndk_version)
-        return join(self.buildozer.global_platform_dir,
-                    'android-ndk-r{0}'.format(version))
+        version = self.buildozer.config.getdefault('app', 'android.ndk', self.android_ndk_version)
+        return join(self.buildozer.global_platform_dir, 'android-ndk-r{0}'.format(version))
 
     @property
     def apache_ant_dir(self):
-        directory = expanduser(self.buildozer.config.getdefault(
-            'app', 'android.ant_path', ''))
+        directory = expanduser(self.buildozer.config.getdefault('app', 'android.ant_path', ''))
         if directory:
             return realpath(directory)
-        version = self.buildozer.config.getdefault('app', 'android.ant',
-                                                   APACHE_ANT_VERSION)
-        return join(self.buildozer.global_platform_dir,
-                    'apache-ant-{0}'.format(version))
+        version = self.buildozer.config.getdefault('app', 'android.ant', APACHE_ANT_VERSION)
+        return join(self.buildozer.global_platform_dir, 'apache-ant-{0}'.format(version))
 
     def check_requirements(self):
+        if sys.platform in ('win32', 'cygwin'):
+            # raise NotImplementedError('Windows platform not yet working for Android')
+            if IS_PY3:
+                input_func = input
+            else:
+                input_func = raw_input
+
+            print('\033[91m\033[1mBuilding using the \'android\' or \'android_new\' toolchains on Windows is very '
+                  'experimental. Things will not work properly, and it is unlikely that the build will succeed.\033[0m')
+
+            cont = None
+            while cont not in ('y', 'n'):
+                cont = input_func('Are you sure you want to continue [y/n]? ')
+
+            if cont == 'n':
+                sys.exit()
         if platform in ('win32', 'cygwin'):
             try:
                 self._set_win32_java_home()
             except:
                 traceback.print_exc()
-            self.android_cmd = join(self.android_sdk_dir, 'tools',
-                                    'android.bat')
-            self.adb_cmd = join(self.android_sdk_dir, 'platform-tools',
-                                'adb.exe')
+            self.android_cmd = join(self.android_sdk_dir, 'tools', 'android.bat')
+            self.adb_cmd = join(self.android_sdk_dir, 'platform-tools', 'adb.exe')
             self.javac_cmd = self._locate_java('javac.exe')
             self.keytool_cmd = self._locate_java('keytool.exe')
-        elif platform in ('darwin', ):
+        elif platform in ('darwin',):
             self.android_cmd = join(self.android_sdk_dir, 'tools', 'android')
             self.adb_cmd = join(self.android_sdk_dir, 'platform-tools', 'adb')
             self.javac_cmd = self._locate_java('javac')
@@ -116,14 +118,10 @@ class TargetAndroid(Target):
             self.keytool_cmd = self._locate_java('keytool')
 
             # Check for C header <zlib.h>.
-            _, _, returncode_dpkg = self.buildozer.cmd('dpkg --version',
-                                                       break_on_error=False)
+            _, _, returncode_dpkg = self.buildozer.cmd('dpkg --version', break_on_error=False)
             is_debian_like = (returncode_dpkg == 0)
-            if is_debian_like and \
-                not self.buildozer.file_exists('/usr/include/zlib.h'):
-                raise BuildozerException(
-                    'zlib headers must be installed, '
-                    'run: sudo apt-get install zlib1g-dev')
+            if is_debian_like and not self.buildozer.file_exists('/usr/include/zlib.h'):
+                raise BuildozerException('zlib headers must be installed, run: sudo apt-get install zlib1g-dev')
 
         # Need to add internally installed ant to path for external tools
         # like adb to use
@@ -145,8 +143,7 @@ class TargetAndroid(Target):
         # check the permission
         available_permissions = self._get_available_permissions()
         if available_permissions:
-            permissions = self.buildozer.config.getlist(
-                'app', 'android.permissions', [])
+            permissions = self.buildozer.config.getlist('app', 'android.permissions', [])
             for permission in permissions:
                 # no check on full named permission
                 # like com.google.android.providers.gsf.permission.READ_GSERVICES
@@ -154,9 +151,7 @@ class TargetAndroid(Target):
                     continue
                 permission = permission.upper()
                 if permission not in available_permissions:
-                    errors.append(
-                        '[app] "android.permission" contain an unknown'
-                        ' permission {0}'.format(permission))
+                    errors.append('[app] "android.permission" contain an unknown permission {0}'.format(permission))
 
         super(TargetAndroid, self).check_configuration_tokens(errors)
 
@@ -174,15 +169,12 @@ class TargetAndroid(Target):
             return self.buildozer.state[key]
 
         try:
-            self.buildozer.debug(
-                'Read available permissions from api-versions.xml')
+            self.buildozer.debug('Read available permissions from api-versions.xml')
             import xml.etree.ElementTree as ET
-            fn = join(self.android_sdk_dir, 'platform-tools', 'api',
-                      'api-versions.xml')
+            fn = join(self.android_sdk_dir, 'platform-tools', 'api', 'api-versions.xml')
             with io.open(fn, encoding='utf-8') as fd:
                 doc = ET.fromstring(fd.read())
-            fields = doc.findall(
-                './/class[@name="android/Manifest$permission"]/field[@name]')
+            fields = doc.findall('.//class[@name="android/Manifest$permission"]/field[@name]')
             available_permissions = [x.attrib['name'] for x in fields]
 
             self.buildozer.state[key] = available_permissions
@@ -194,16 +186,16 @@ class TargetAndroid(Target):
     def _set_win32_java_home(self):
         if 'JAVA_HOME' in self.buildozer.environ:
             return
-        import _winreg
-        with _winreg.OpenKey(
-                _winreg.HKEY_LOCAL_MACHINE,
-                r"SOFTWARE\JavaSoft\Java Development Kit") as jdk:  #@UndefinedVariable
-            current_version, _type = _winreg.QueryValueEx(
-                jdk, "CurrentVersion")  #@UndefinedVariable
-            with _winreg.OpenKey(jdk,
-                                 current_version) as cv:  #@UndefinedVariable
-                java_home, _type = _winreg.QueryValueEx(
-                    cv, "JavaHome")  #@UndefinedVariable
+        if sys.version_info >= (3, 0):
+            import winreg as _winreg
+        else:
+            import _winreg
+
+        with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
+                             r"SOFTWARE\JavaSoft\Java Development Kit") as jdk:  # @UndefinedVariable
+            current_version, _type = _winreg.QueryValueEx(jdk, "CurrentVersion")  # @UndefinedVariable
+            with _winreg.OpenKey(jdk, current_version) as cv:  # @UndefinedVariable
+                java_home, _type = _winreg.QueryValueEx(cv, "JavaHome")  # @UndefinedVariable
             self.buildozer.environ['JAVA_HOME'] = java_home
 
     def _locate_java(self, s):
@@ -224,11 +216,8 @@ class TargetAndroid(Target):
         self.buildozer.info('Android ANT is missing, downloading')
         archive = 'apache-ant-{0}-bin.tar.gz'.format(APACHE_ANT_VERSION)
         url = 'http://archive.apache.org/dist/ant/binaries/'
-        self.buildozer.download(url,
-                                archive,
-                                cwd=self.buildozer.global_platform_dir)
-        self.buildozer.file_extract(archive,
-                                    cwd=self.buildozer.global_platform_dir)
+        self.buildozer.download(url, archive, cwd=self.buildozer.global_platform_dir)
+        self.buildozer.file_extract(archive, cwd=self.buildozer.global_platform_dir)
         self.buildozer.info('Apache ANT installation done.')
         return ant_dir
 
@@ -242,7 +231,7 @@ class TargetAndroid(Target):
         if platform in ('win32', 'cygwin'):
             archive = 'android-sdk_r{0}-windows.zip'
             unpacked = 'android-sdk-windows'
-        elif platform in ('darwin', ):
+        elif platform in ('darwin',):
             archive = 'android-sdk_r{0}-macosx.zip'
             unpacked = 'android-sdk-macosx'
         elif platform.startswith('linux'):
@@ -258,11 +247,8 @@ class TargetAndroid(Target):
                                 cwd=self.buildozer.global_platform_dir)
 
         self.buildozer.info('Unpacking Android SDK')
-        self.buildozer.file_extract(archive,
-                                    cwd=self.buildozer.global_platform_dir)
-        self.buildozer.file_rename(unpacked,
-                                   sdk_dir,
-                                   cwd=self.buildozer.global_platform_dir)
+        self.buildozer.file_extract(archive, cwd=self.buildozer.global_platform_dir)
+        self.buildozer.file_rename(unpacked, sdk_dir, cwd=self.buildozer.global_platform_dir)
         self.buildozer.info('Android SDK installation done.')
 
         return sdk_dir
@@ -283,7 +269,7 @@ class TargetAndroid(Target):
             archive = 'android-ndk-r{0}-windows-{1}.zip'
             is_64 = (8 * struct.calcsize("P") == 64)
 
-        elif platform in ('darwin', ):
+        elif platform in ('darwin',):
             if int(_version) > 9:
                 archive = 'android-ndk-r{0}-darwin-{1}.bin'
             else:
@@ -303,17 +289,13 @@ class TargetAndroid(Target):
         unpacked = 'android-ndk-r{0}'
         archive = archive.format(self.android_ndk_version, architecture)
         unpacked = unpacked.format(self.android_ndk_version)
-        url = 'http://dl.google.com/android/ndk/'
-        self.buildozer.download(url,
-                                archive,
-                                cwd=self.buildozer.global_platform_dir)
+        # url = 'http://dl.google.com/android/ndk/'
+        url = 'http://dl.google.com/android/repository/'
+        self.buildozer.download(url, archive, cwd=self.buildozer.global_platform_dir)
 
         self.buildozer.info('Unpacking Android NDK')
-        self.buildozer.file_extract(archive,
-                                    cwd=self.buildozer.global_platform_dir)
-        self.buildozer.file_rename(unpacked,
-                                   ndk_dir,
-                                   cwd=self.buildozer.global_platform_dir)
+        self.buildozer.file_extract(archive, cwd=self.buildozer.global_platform_dir)
+        self.buildozer.file_rename(unpacked, ndk_dir, cwd=self.buildozer.global_platform_dir)
         self.buildozer.info('Android NDK installation done.')
         return ndk_dir
 
@@ -321,14 +303,10 @@ class TargetAndroid(Target):
         cmd = '{} list sdk -u -e'.format(self.android_cmd)
         if include_all:
             cmd += ' -a'
-        available_packages = self.buildozer.cmd(
-            cmd,
-            cwd=self.buildozer.global_platform_dir,
-            get_stdout=True)[0]
+        available_packages = self.buildozer.cmd(cmd, cwd=self.buildozer.global_platform_dir, get_stdout=True)[0]
 
         # get only the line like -> id: 5 or "build-tools-19.0.1"
         # and extract the name part.
-        print(available_packages)
         return [x.split('"')[1]
                 for x in available_packages.splitlines()
                 if x.startswith('id: ')]
@@ -336,16 +314,10 @@ class TargetAndroid(Target):
     def _android_update_sdk(self, packages):
         from pexpect import EOF
         java_tool_options = environ.get('JAVA_TOOL_OPTIONS', '')
-        child = self.buildozer.cmd_expect(
-            '{} update sdk -u -a -t {}'.format(
-                self.android_cmd,
-                packages,
-                cwd=self.buildozer.global_platform_dir),
-            timeout=None,
-            env={
-                'JAVA_TOOL_OPTIONS': java_tool_options +
-                ' -Dfile.encoding=UTF-8'
-            })
+        child = self.buildozer.cmd_expect('{} update sdk -u -a -t {}'.format(self.android_cmd, packages,
+                                                                             cwd=self.buildozer.global_platform_dir),
+                                          timeout=None,
+                                          env={'JAVA_TOOL_OPTIONS': java_tool_options + ' -Dfile.encoding=UTF-8'})
         while True:
             index = child.expect([EOF, u'[y/n]: '])
             if index == 0:
@@ -358,8 +330,7 @@ class TargetAndroid(Target):
     def _read_version_subdir(self, *args):
         versions = []
         if not os.path.exists(join(*args)):
-            self.buildozer.debug('build-tools folder not found {}'.format(join(
-                *args)))
+            self.buildozer.debug('build-tools folder not found {}'.format(join(*args)))
             return parse("0")
         for v in os.listdir(join(*args)):
             try:
@@ -367,8 +338,7 @@ class TargetAndroid(Target):
             except:
                 pass
         if not versions:
-            self.buildozer.error(
-                'Unable to find the latest version for {}'.format(join(*args)))
+            self.buildozer.error('Unable to find the latest version for {}'.format(join(*args)))
             return parse("0")
         return max(versions)
 
@@ -402,8 +372,7 @@ class TargetAndroid(Target):
 
         # 1. update the tool and platform-tools if needed
         packages = self._android_list_sdk()
-        skip_upd = self.buildozer.config.getdefault('app',
-                                                    'android.skip_update', False)
+        skip_upd = self.buildozer.config.getdefault('app', 'android.skip_update', False)
         if 'tools' in packages or 'platform-tools' in packages:
             if not skip_upd:
                 self._android_update_sdk('tools,platform-tools')
@@ -411,19 +380,16 @@ class TargetAndroid(Target):
                 self.buildozer.info('Skipping Android SDK update due to spec file setting')
 
         # 2. install the latest build tool
-        v_build_tools = self._read_version_subdir(self.android_sdk_dir,
-                                                  'build-tools')
+        v_build_tools = self._read_version_subdir(self.android_sdk_dir, 'build-tools')
         packages = self._android_list_sdk(include_all=True)
         ver = self._find_latest_package(packages, 'build-tools-')
         if ver and ver > v_build_tools:
-            self._android_update_sdk(self._build_package_string('build-tools',
-                                                                ver))
+            self._android_update_sdk(self._build_package_string('build-tools', ver))
         # 2.bis check aidl can be runned
         self._check_aidl(v_build_tools)
 
         # 3. finally, install the android for the current api
-        android_platform = join(self.android_sdk_dir, 'platforms',
-                                'android-{0}'.format(self.android_api))
+        android_platform = join(self.android_sdk_dir, 'platforms', 'android-{0}'.format(self.android_api))
         if not self.buildozer.file_exists(android_platform):
             packages = self._android_list_sdk()
             android_package = 'android-{}'.format(self.android_api)
@@ -437,61 +403,45 @@ class TargetAndroid(Target):
 
     def _check_aidl(self, v_build_tools):
         self.buildozer.debug('Check that aidl can be executed')
-        v_build_tools = self._read_version_subdir(self.android_sdk_dir,
-                                                  'build-tools')
-        aidl_cmd = join(self.android_sdk_dir, 'build-tools',
-                        str(v_build_tools), 'aidl')
+        v_build_tools = self._read_version_subdir(self.android_sdk_dir, 'build-tools')
+        aidl_cmd = join(self.android_sdk_dir, 'build-tools', str(v_build_tools), 'aidl')
         self.buildozer.checkbin('Aidl', aidl_cmd)
-        _, _, returncode = self.buildozer.cmd(aidl_cmd,
-                                              break_on_error=False,
-                                              show_output=False)
+        _, _, returncode = self.buildozer.cmd(aidl_cmd, break_on_error=False, show_output=False)
         if returncode != 1:
             self.buildozer.error('Aidl cannot be executed')
-            if sys.maxint > 2**32:
+            if sys.maxint > 2 ** 32:
                 self.buildozer.error('')
-                self.buildozer.error(
-                    'You might have missed to install 32bits libs')
-                self.buildozer.error(
-                    'Check http://buildozer.readthedocs.org/en/latest/installation.html')
+                self.buildozer.error('You might have missed to install 32bits libs')
+                self.buildozer.error('Check http://buildozer.readthedocs.org/en/latest/installation.html')
                 self.buildozer.error('')
             else:
                 self.buildozer.error('')
-                self.buildozer.error(
-                    'In case of a bug report, please add a full log with log_level = 2')
+                self.buildozer.error('In case of a bug report, please add a full log with log_level = 2')
                 self.buildozer.error('')
             raise BuildozerException()
 
     def install_platform(self):
         cmd = self.buildozer.cmd
-        source = self.buildozer.config.getdefault('app', 'android.branch',
-                                                  self.p4a_branch)
-        self.pa_dir = pa_dir = join(self.buildozer.platform_dir,
-                                    self.p4a_directory)
-        system_p4a_dir = self.buildozer.config.getdefault('app',
-                                                          'android.p4a_dir')
+        source = self.buildozer.config.getdefault('app', 'android.branch', self.p4a_branch)
+        self.pa_dir = pa_dir = join(self.buildozer.platform_dir, self.p4a_directory)
+        system_p4a_dir = self.buildozer.config.getdefault('app', 'android.p4a_dir')
         if system_p4a_dir:
             self.pa_dir = pa_dir = expanduser(system_p4a_dir)
             if not self.buildozer.file_exists(pa_dir):
-                self.buildozer.error(
-                    'Path for android.p4a_dir does not exist')
+                self.buildozer.error('Path for android.p4a_dir does not exist')
                 self.buildozer.error('')
                 raise BuildozerException()
         else:
             if not self.buildozer.file_exists(pa_dir):
-                cmd(
-                    ('git clone -b {} --single-branch '
-                     'https://github.com/kivy/python-for-android.git '
-                     '{}').format(source, self.p4a_directory),
-                    cwd=self.buildozer.platform_dir)
+                cmd(('git clone -b {} --single-branch https://github.com/kivy/python-for-android.git '
+                     '{}').format(source, self.p4a_directory), cwd=self.buildozer.platform_dir)
             elif self.platform_update:
                 cmd('git clean -dxf', cwd=pa_dir)
-                current_branch = cmd('git rev-parse --abbrev-ref HEAD',
-                                     get_stdout=True, cwd=pa_dir)[0].strip()
+                current_branch = cmd('git rev-parse --abbrev-ref HEAD', get_stdout=True, cwd=pa_dir)[0].strip()
                 if current_branch == source:
                     cmd('git pull', cwd=pa_dir)
                 else:
-                    cmd('git fetch --tags origin {0}:{0}'.format(source),
-                        cwd=pa_dir)
+                    cmd('git fetch --tags origin {0}:{0}'.format(source), cwd=pa_dir)
                     cmd('git checkout {}'.format(source), cwd=pa_dir)
 
         self._install_apache_ant()
@@ -522,18 +472,14 @@ class TargetAndroid(Target):
     def compile_platform(self):
         # for android, the compilation depends really on the app requirements.
         # compile the distribution only if the requirements changed.
-        last_requirements = self.buildozer.state.get('android.requirements',
-                                                     '')
-        app_requirements = self.buildozer.config.getlist('app', 'requirements',
-                                                         '')
+        last_requirements = self.buildozer.state.get('android.requirements', '')
+        app_requirements = self.buildozer.config.getlist('app', 'requirements', '')
 
         # we need to extract the requirements that python-for-android knows
         # about
         available_modules = self.get_available_packages()
         onlyname = lambda x: x.split('==')[0]
-        android_requirements = [x
-                                for x in app_requirements
-                                if onlyname(x) in available_modules]
+        android_requirements = [x for x in app_requirements if onlyname(x) in available_modules]
 
         need_compile = 0
         if last_requirements != android_requirements:
@@ -541,25 +487,21 @@ class TargetAndroid(Target):
 
         dist_name = self.buildozer.config.get('app', 'package.name')
         dist_dir = join(self.pa_dir, 'dist', dist_name)
-        dist_file = join(dist_dir, 'private', 'include', 'python2.7',
-                         'pyconfig.h')
+        dist_file = join(dist_dir, 'private', 'include', 'python2.7', 'pyconfig.h')
         if not exists(dist_file):
             need_compile = 1
 
         # len('requirements.source.') == 20, so use name[20:]
-        source_dirs = {
-            'P4A_{}_DIR'.format(name[20:]): realpath(expanduser(value))
-            for name, value in self.buildozer.config.items('app')
-            if name.startswith('requirements.source.')
-        }
+        source_dirs = {'P4A_{}_DIR'.format(name[20:]): realpath(expanduser(value))
+                       for name, value in self.buildozer.config.items('app')
+                       if name.startswith('requirements.source.')
+                       }
         if source_dirs:
             self.buildozer.environ.update(source_dirs)
-            self.buildozer.info('Using custom source dirs:\n    {}'.format(
-                '\n    '.join(['{} = {}'.format(k, v)
-                               for k, v in source_dirs.items()])))
+            self.buildozer.info('Using custom source dirs:\n    {}'.format('\n    '.join(
+                ['{} = {}'.format(k, v) for k, v in source_dirs.items()])))
 
-        last_source_requirements = self.buildozer.state.get(
-            'android.requirements.source', {})
+        last_source_requirements = self.buildozer.state.get('android.requirements.source', {})
         if source_dirs != last_source_requirements:
             need_compile = 1
 
@@ -572,8 +514,7 @@ class TargetAndroid(Target):
         self.buildozer.debug('Clean and build python-for-android')
         self.buildozer.rmdir(dist_dir)  # Delete existing distribution to stop
         # p4a complaining
-        cmd('./distribute.sh -m "{0}" -d "{1}"'.format(modules_str, dist_name),
-            cwd=self.pa_dir)
+        cmd('./distribute.sh -m "{0}" -d "{1}"'.format(modules_str, dist_name), cwd=self.pa_dir)
         self.buildozer.debug('Remove temporary build files')
         self.buildozer.rmdir(join(self.pa_dir, 'build'))
         self.buildozer.rmdir(join(self.pa_dir, '.packages'))
@@ -594,8 +535,7 @@ class TargetAndroid(Target):
         return package.lower()
 
     def _generate_whitelist(self, dist_dir):
-        p4a_whitelist = self.buildozer.config.getlist(
-            'app', 'android.p4a_whitelist') or []
+        p4a_whitelist = self.buildozer.config.getlist('app', 'android.p4a_whitelist') or []
         whitelist_fn = join(dist_dir, 'whitelist.txt')
         with open(whitelist_fn, 'w') as fd:
             for wl in p4a_whitelist:
@@ -627,10 +567,10 @@ class TargetAndroid(Target):
         # add extra libs/armeabi files in dist/default/libs/armeabi
         # (same for armeabi-v7a, x86, mips)
         for config_key, lib_dir in (
-            ('android.add_libs_armeabi', 'armeabi'),
-            ('android.add_libs_armeabi_v7a', 'armeabi-v7a'),
-            ('android.add_libs_x86', 'x86'),
-            ('android.add_libs_mips', 'mips')):
+                ('android.add_libs_armeabi', 'armeabi'),
+                ('android.add_libs_armeabi_v7a', 'armeabi-v7a'),
+                ('android.add_libs_x86', 'x86'),
+                ('android.add_libs_mips', 'mips')):
 
             patterns = config.getlist('app', config_key, [])
             if not patterns:
@@ -638,9 +578,8 @@ class TargetAndroid(Target):
 
             self.buildozer.debug('Search and copy libs for {}'.format(lib_dir))
             for fn in self.buildozer.file_matches(patterns):
-                self.buildozer.file_copy(
-                    join(self.buildozer.root_dir, fn),
-                    join(dist_dir, 'libs', lib_dir, basename(fn)))
+                self.buildozer.file_copy(join(self.buildozer.root_dir, fn),
+                                         join(dist_dir, 'libs', lib_dir, basename(fn)))
 
         # update the project.properties libraries references
         self._update_libraries_references(dist_dir)
@@ -659,10 +598,9 @@ class TargetAndroid(Target):
             ("--sdk", config.getdefault('app', 'android.api',
                                         self.android_api)),
             ("--minsdk", config.getdefault('app', 'android.minapi',
-                                           self.android_minapi)),
+                                           self.android_minapi))
         ]
-        is_private_storage = config.getbooldefault(
-            'app', 'android.private_storage', True)
+        is_private_storage = config.getbooldefault('app', 'android.private_storage', True)
         if is_private_storage:
             build_cmd += [("--private", self.buildozer.app_dir)]
         else:
@@ -693,8 +631,7 @@ class TargetAndroid(Target):
                 for jar in matches:
                     build_cmd += [("--add-jar", jar)]
             else:
-                raise SystemError('Failed to find jar file: {}'.format(
-                    pattern))
+                raise SystemError('Failed to find jar file: {}'.format(pattern))
 
         # add presplash
         presplash = config.getdefault('app', 'presplash.filename', '')
@@ -708,13 +645,11 @@ class TargetAndroid(Target):
             build_cmd += [("--icon", join(self.buildozer.root_dir, icon))]
 
         # OUYA Console support
-        ouya_category = config.getdefault('app', 'android.ouya.category',
-                                          '').upper()
+        ouya_category = config.getdefault('app', 'android.ouya.category', '').upper()
         if ouya_category:
             if ouya_category not in ('GAME', 'APP'):
-                raise SystemError(
-                    'Invalid android.ouya.category: "{}" must be one of GAME or APP'.format(
-                        ouya_category))
+                raise SystemError('Invalid android.ouya.category: "{}" must be one of GAME or '
+                                  'APP'.format(ouya_category))
             # add icon
             ouya_icon = config.getdefault('app', 'android.ouya.icon.filename',
                                           '')
@@ -731,26 +666,25 @@ class TargetAndroid(Target):
         # fullscreen ?
         fullscreen = config.getbooldefault('app', 'fullscreen', True)
         if not fullscreen:
-            build_cmd += [("--window", )]
+            build_cmd += [("--window",)]
 
         # wakelock ?
         wakelock = config.getbooldefault('app', 'android.wakelock', False)
         if wakelock:
-            build_cmd += [("--wakelock", )]
+            build_cmd += [("--wakelock",)]
 
         # intent filters
-        intent_filters = config.getdefault(
-            'app', 'android.manifest.intent_filters', '')
+        intent_filters = config.getdefault('app', 'android.manifest.intent_filters', '')
         if intent_filters:
             build_cmd += [("--intent-filters", join(self.buildozer.root_dir,
                                                     intent_filters))]
 
         # build only in debug right now.
         if self.build_mode == 'debug':
-            build_cmd += [("debug", )]
+            build_cmd += [("debug",)]
             mode = 'debug'
         else:
-            build_cmd += [("release", )]
+            build_cmd += [("release",)]
             mode = 'release'
 
         self.execute_build_package(build_cmd)
@@ -769,17 +703,13 @@ class TargetAndroid(Target):
         if hasattr(apptitle, 'decode'):
             apptitle = apptitle.decode('utf-8')
         apktitle = ''.join([x for x in apptitle if x not in bl])
-        apk = u'{title}-{version}-{mode}.apk'.format(
-            title=apktitle,
-            version=version,
-            mode=mode)
+        apk = u'{title}-{version}-{mode}.apk'.format(title=apktitle, version=version, mode=mode)
 
         # copy to our place
         copyfile(join(dist_dir, 'bin', apk), join(self.buildozer.bin_dir, apk))
 
         self.buildozer.info('Android packaging done!')
-        self.buildozer.info(
-            u'APK {0} available in the bin directory'.format(apk))
+        self.buildozer.info(u'APK {0} available in the bin directory'.format(apk))
         self.buildozer.state['android:latestapk'] = apk
         self.buildozer.state['android:latestmode'] = self.build_mode
 
@@ -801,17 +731,13 @@ class TargetAndroid(Target):
             content.remove(line)
 
         # convert our references to relative path
-        app_references = self.buildozer.config.getlist(
-            'app', 'android.library_references', [])
-        source_dir = realpath(self.buildozer.config.getdefault(
-            'app', 'source.dir', '.'))
+        app_references = self.buildozer.config.getlist('app', 'android.library_references', [])
+        source_dir = realpath(self.buildozer.config.getdefault('app', 'source.dir', '.'))
         for cref in app_references:
             # get the full path of the current reference
             ref = realpath(join(source_dir, cref))
             if not self.buildozer.file_exists(ref):
-                self.buildozer.error(
-                    'Invalid library reference (path not found): {}'.format(
-                        cref))
+                self.buildozer.error('Invalid library reference (path not found): {}'.format(cref))
                 exit(1)
             # get a relative path from the project file
             ref = relpath(ref, realpath(dist_dir))
@@ -822,8 +748,7 @@ class TargetAndroid(Target):
         with io.open(project_fn, 'w', encoding='utf-8') as fd:
             fd.writelines(content)
             for index, ref in enumerate(references):
-                fd.write(u'android.library.reference.{}={}\n'.format(index + 1,
-                                                                     ref))
+                fd.write(u'android.library.reference.{}={}\n'.format(index + 1, ref))
 
         self.buildozer.debug('project.properties updated')
 
@@ -842,8 +767,7 @@ class TargetAndroid(Target):
         serial = environ.get('ANDROID_SERIAL')
         if serial:
             return serial.split(',')
-        l = self.buildozer.cmd('{} devices'.format(self.adb_cmd),
-                               get_stdout=True)[0].splitlines()
+        l = self.buildozer.cmd('{} devices'.format(self.adb_cmd), get_stdout=True)[0].splitlines()
         serials = []
         for serial in l:
             if not serial:
@@ -865,8 +789,7 @@ class TargetAndroid(Target):
         args = args[0]
         if args and args[0] == '--alias':
             print('To set up ADB in this shell session, execute:')
-            print('    alias adb=$(buildozer {} adb --alias 2>&1 >/dev/null)'
-                  .format(self.targetname))
+            print('    alias adb=$(buildozer {} adb --alias 2>&1 >/dev/null)'.format(self.targetname))
             sys.stderr.write(self.adb_cmd + '\n')
         else:
             self.buildozer.cmd(' '.join([self.adb_cmd] + args))
@@ -884,15 +807,13 @@ class TargetAndroid(Target):
         apk = state['android:latestapk']
         full_apk = join(self.buildozer.bin_dir, apk)
         if not self.buildozer.file_exists(full_apk):
-            self.buildozer.error(
-                'Unable to found the latest APK. Please run "debug" again.')
+            self.buildozer.error('Unable to found the latest APK. Please run "debug" again.')
 
         # push on the device
         for serial in self.serials:
             self.buildozer.environ['ANDROID_SERIAL'] = serial
             self.buildozer.info('Deploy on {}'.format(serial))
-            self.buildozer.cmd('{0} install -r {1}'.format(self.adb_cmd,
-                                                           full_apk),
+            self.buildozer.cmd('{0} install -r {1}'.format(self.adb_cmd, full_apk),
                                cwd=self.buildozer.global_platform_dir)
         self.buildozer.environ.pop('ANDROID_SERIAL', None)
 
@@ -901,20 +822,17 @@ class TargetAndroid(Target):
     def cmd_run(self, *args):
         super(TargetAndroid, self).cmd_run(*args)
 
-        entrypoint = self.buildozer.config.getdefault(
-            'app', 'android.entrypoint', 'org.renpy.android.PythonActivity')
+        entrypoint = self.buildozer.config.getdefault('app', 'android.entrypoint', 'org.renpy.android.PythonActivity')
         package = self._get_package()
 
         # push on the device
         for serial in self.serials:
             self.buildozer.environ['ANDROID_SERIAL'] = serial
             self.buildozer.info('Run on {}'.format(serial))
-            self.buildozer.cmd(
-                '{adb} shell am start -n {package}/{entry} -a {entry}'.format(
-                    adb=self.adb_cmd,
-                    package=package,
-                    entry=entrypoint),
-                cwd=self.buildozer.global_platform_dir)
+            self.buildozer.cmd('{adb} shell am start -n {package}/{entry} -a {entry}'.format(adb=self.adb_cmd,
+                                                                                             package=package,
+                                                                                             entry=entrypoint),
+                               cwd=self.buildozer.global_platform_dir)
         self.buildozer.environ.pop('ANDROID_SERIAL', None)
 
         self.buildozer.info('Application started.')
@@ -926,12 +844,11 @@ class TargetAndroid(Target):
         serial = self.serials[0:]
         if not serial:
             return
-        filters = self.buildozer.config.getrawdefault(
-            "app", "android.logcat_filters", "", section_sep=":", split_char=" ")
+        filters = self.buildozer.config.getrawdefault("app", "android.logcat_filters", "", section_sep=":",
+                                                      split_char=" ")
         filters = " ".join(filters)
         self.buildozer.environ['ANDROID_SERIAL'] = serial[0]
-        self.buildozer.cmd('{adb} logcat {filters}'.format(adb=self.adb_cmd,
-                                                           filters=filters),
+        self.buildozer.cmd('{adb} logcat {filters}'.format(adb=self.adb_cmd, filters=filters),
                            cwd=self.buildozer.global_platform_dir,
                            show_output=True)
         self.buildozer.environ.pop('ANDROID_SERIAL', None)
@@ -939,4 +856,3 @@ class TargetAndroid(Target):
 
 def get_target(buildozer):
     return TargetAndroid(buildozer)
-


### PR DESCRIPTION
#### Fixes:

* Buildozer.checkbin looking for files without an extension (without '.exe' so it would never find Git or Cython)
* NDK, SDK and Ant downloading now works.
* Formatting fixes in ```toolchains/android.py```

#### Dependencies:

Ports of the normal Linux P4A dependencies can be downloaded from here: http://gnuwin32.sourceforge.net/packages.html

* GZip: http://gnuwin32.sourceforge.net/packages/gzip.htm
* Tar: http://gnuwin32.sourceforge.net/packages/gtar.htm
* UnZip: http://gnuwin32.sourceforge.net/packages/unzip.htm


#### Issues

Buildozer crashes when trying to do Buildozer.cmd(get_stdout=True), as it is unable to get get_stdout: (below is an error from when it tries to list the SDK)
```
  File "C:\Python35\lib\site-packages\buildozer-0.33.dev0-py3.5.egg\buildozer\targets\android.py", line 355, in _android_list_sdk
    for x in available_packages.splitlines()
AttributeError: 'NoneType' object has no attribute 'splitlines'
```
But, the actual exception is:
```
  File "C:\Python35\lib\site-packages\buildozer-0.33.dev0-py3.5.egg\buildozer\__init__.py", line 307, in cmd
    readx = select.select([fd_stdout, fd_stderr], [], [])[0]
OSError: [WinError 10038] An operation was attempted on something that is not a socket
```

There are definitely more issues that happen later down the line, but I want to get this one sorted out first. 