### PR TITLE
Add 404 status code handling on kivy download

### DIFF
--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -60,11 +60,18 @@ class TargetOSX(Target):
         else:
             if not exists(join(cwd, 'Kivy{}.dmg'.format(py_branch))):
                 self.buildozer.info('Downloading kivy...')
-                check_call(
-                    ('curl', '-L', '-o', 'Kivy{}.dmg'.format(py_branch),
+                status_code = check_output(
+                    ('curl', '-L', '--write-out', '%{http_code}', '-o', 'Kivy{}.dmg'.format(py_branch),
                     'http://kivy.org/downloads/{}/Kivy-{}-osx-python{}.dmg'\
                     .format(current_kivy_vers, current_kivy_vers, py_branch)),
                     cwd=cwd)
+
+                if status_code == "404":
+                    self.buildozer.error(
+                        "Unable to download the Kivy App. Check osx.kivy_version in your buildozer.spec, and verify "
+                        "Kivy servers are accessible. http://kivy.org/downloads/")
+                    check_call(("rm", "Kivy{}.dmg".format(py_branch)), cwd=cwd)
+                    exit(1)
 
             self.buildozer.info('Extracting and installing Kivy...')
             check_call(('hdiutil', 'attach', cwd + '/Kivy{}.dmg'.format(py_branch)))


### PR DESCRIPTION
Since the Kivy Downloads section is down due to https://github.com/kivy/kivy/issues/5211 the OSX build target has been failing if you are missing the Kivy dependency. (It's been a couple days since it's been taken down, and troubleshooting this is pretty annoying for any devs who clean their build environment.)

This PR will handle the case when the Kivy dependency cannot be downloaded. It will cover the case where the server returns 404, (such is the case now). It will also cover when a user specifies an incorrect kivy version in osx.kivy_version.