### PR TITLE
Fix unicode coding error in android build target

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -851,7 +851,7 @@ class TargetAndroid(Target):
         # recreate the project.properties
         with io.open(project_fn, 'w', encoding='utf-8') as fd:
             try:
-                fd.writelines((line.encode('utf-8') for line in content))
+                fd.writelines((line.decode('utf-8') for line in content))
             except:
                 fd.writelines(content)
             if not content[-1].endswith(u'\n'):


### PR DESCRIPTION
Using Python 2.7, attempting to run `encode(utf-8)` was throwing `write() argument 1 must be unicode, not str`.

As the file being written has `encoding='utf-8'`, I'm assuming the intention was to decode the lines from an `str` into a unicode string, and I believe that's what this change does.

Please let me know if I've misinterpreted something. Making this change fixed my build locally. Also not sure where I should be targeting this, but it seemed like it might qualify as a hotfix, so I'm targeting master for now.

Also, thank you once again for all the amazing work being done by Kivy! We're porting https://learningequality.org/kolibri/ (the successor platform to KA Lite, our offline version of Khan Academy that I told you about at PyCon 2013) from `python-android` to `kivy/python-for-android` with the webview bootstrap, and it's so awesome. :heart: (Cuts our Android code down from thousands of lines of Java to 40 lines of Python!)