### PR TITLE
Update android.py, updated recreate the project.properties section

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -851,7 +851,7 @@ class TargetAndroid(Target):
         # recreate the project.properties
         with io.open(project_fn, 'w', encoding='utf-8') as fd:
             try:
-                fd.writelines((line.encode('utf-8') for line in content))
+                fd.writelines((line.decode('utf-8') for line in content))
             except:
                 fd.writelines(content)
             if not content[-1].endswith(u'\n'):


### PR DESCRIPTION
Using android_old option exits with error due to an empty "project.properties" file. To solve this problem the next edit should be done:

In recreate the project.properties section, the next line should be changed:
`fd.writelines((line.encode('utf-8') for line in content))` 
-->
`fd.writelines((line.decode('utf-8') for line in content))`

