### PR TITLE
Changed p4a directory name for current toolchain

### DIFF
--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -13,7 +13,7 @@ from os.path import join, expanduser, realpath
 class TargetAndroidNew(TargetAndroid):
     targetname = 'android'
     p4a_branch = "stable"
-    p4a_directory = "python-for-android-master"
+    p4a_directory = "python-for-android-new-toolchain"
     p4a_apk_cmd = "apk --debug --bootstrap="
     extra_p4a_args = ''
 


### PR DESCRIPTION
I just saw a p4a issue that assumed the directory `python-for-android-master` was actually the master branch, which it doesn't seem to be. Just changing the directory name seems clear and uncontroversial.