### PR TITLE
Removed --sdk argument for p4a

### DIFF
--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -98,8 +98,6 @@ class TargetAndroidNew(TargetAndroid):
             elif option == "--sdk":
                 cmd.append("--android_api")
                 cmd.extend(values)
-                cmd.append("--sdk")
-                cmd.extend(values)
             else:
                 cmd.extend(args)
 


### PR DESCRIPTION
This argument no longer does anything.

Actually I didn't realise buildozer used it and removed it entirely, causing the build to crash. I've already pushed a fix for that to p4a, but the argument still won't do anything.