### PR TITLE
Fix old toolchain index error

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -854,7 +854,7 @@ class TargetAndroid(Target):
                 fd.writelines((line.encode('utf-8') for line in content))
             except:
                 fd.writelines(content)
-            if not content[-1].endswith(u'\n'):
+            if content and not content[-1].endswith(u'\n'):
                 fd.write(u'\n')
             for index, ref in enumerate(references):
                 fd.write(u'android.library.reference.{}={}\n'.format(index + 1, ref))


### PR DESCRIPTION
Fixes the following error using the olds toolchain

...File "/home/kivy/Repos/buildozer/buildozer/targets/android.py", line 857, in _update_libraries_references
    if not content[-1].endswith(u'\n'):
IndexError: list index out of range            