### PR TITLE
Fix Py3 utf-8 encode error

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -311,7 +311,7 @@ class Buildozer(object):
                     ret_stdout.append(chunk)
                 if show_output:
                     if IS_PY3:
-                        stdout.write(chunk.decode('utf-8'))
+                        stdout.write(str(chunk))
                     else:
                         stdout.write(chunk)
             if fd_stderr in readx:


### PR DESCRIPTION
When running buildozer using Python 3.5, I get
```
File "/home/richard/Repos/buildozer/buildozer/targets/android.py", line 974, in cmd_logcat
    show_output=True)
  File "/home/richard/Repos/buildozer/buildozer/__init__.py", line 314, in cmd
    stdout.write(chunk.decode('utf-8'))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 12525: invalid start byte
```
This PR seems to fix it :-)