### PR TITLE
Allow adding Java activities to the manifest

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -146,6 +146,9 @@ fullscreen = 0
 # bootstrap)
 #android.gradle_dependencies =
 
+# (list) Java classes to add as activities to the manifest.
+#android.add_activites = com.example.ExampleActivity
+
 # (str) python-for-android branch to use, defaults to stable
 #p4a.branch = stable
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -719,6 +719,11 @@ class TargetAndroid(Target):
                 raise SystemError('Failed to find jar file: {}'.format(
                     pattern))
 
+        # add Java activity
+        add_activities = config.getlist('app', 'android.add_activities', [])
+        for activity in add_activities:
+            build_cmd += [("--add-activity", activity)]
+        
         # add presplash
         presplash = config.getdefault('app', 'presplash.filename', '')
         if presplash:


### PR DESCRIPTION
This depends on kivy/python-for-android#1213.

This feature will allow users to add their own activities to the manifest file. It can be used to start Java activities using pyjnius. See kivy/python-for-android#1213 for more information.