### PR TITLE
allow setting launchMode for the main activity in the manifest

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -162,6 +162,9 @@ fullscreen = 0
 # (str) XML file to include as an intent filters in <activity> tag
 #android.manifest.intent_filters =
 
+# (str) launchMode to set for the main activity
+#android.manifest.launch_mode = standard
+
 # (list) Android additionnal libraries to copy into libs/armeabi
 #android.add_libs_armeabi = libs/android/*.so
 #android.add_libs_armeabi_v7a = libs/android-v7/*.so

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -773,6 +773,12 @@ class TargetAndroid(Target):
             build_cmd += [("--intent-filters", join(self.buildozer.root_dir,
                                                     intent_filters))]
 
+        # activity launch mode
+        launch_mode = config.getdefault(
+            'app', 'android.manifest.launch_mode', '')
+        if launch_mode:
+            build_cmd += [("--activity-launch-mode", launch_mode)]
+
         # build only in debug right now.
         if self.build_mode == 'debug':
             build_cmd += [("debug", )]


### PR DESCRIPTION
As in title, this allows setting the [activity launch mode](https://developer.android.com/guide/topics/manifest/activity-element.html#lmode) in the AndroidManifest from buildozer.spec.

It is cumbersome to manually (or via custom scripts) modify the manifest at `[app project]/.buildozer/android/platform/python-for-android/dist/[app]/templates/AndroidManifest.tmpl.xml`.

related: https://github.com/kivy/python-for-android/pull/1256