### PR TITLE
fix prerelease version

### DIFF
--- a/buildozer/libs/version.py
+++ b/buildozer/libs/version.py
@@ -255,7 +255,7 @@ class Version(_BaseVersion):
 
         # Pre-release
         if self._version.pre is not None:
-            parts.append("".join(str(x) for x in self._version.pre))
+            parts.append("-" + "".join(str(x) for x in self._version.pre))
 
         # Post-release
         if self._version.post is not None:


### PR DESCRIPTION
Fixes an issue where prerelease versions were parsed correctly, but not converted to a string correctly.

For example:
Build tools version "28.0.0-rc1" was parsed as "28.0.0rc1", resulting in the following error:
```bash
# Aidl not found, please install it.
```

This might be a poor fix, and could cause issues elsewhere, so I'm happy to make any necessary changes.