### PR TITLE
buildozer Dockerfile, fixes #589

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Dockerfile for providing buildozer
+# Build with:
+# docker build --tag=buildozer .
+# In order to give the container access to your current working directory
+# it must be mounted using the --volume option.
+# Run with (e.g. `buildozer --version`):
+# docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+# Or for interactive shell:
+# docker run --volume "$(pwd)":/home/user/hostcwd --entrypoint /bin/bash -it --rm buildozer
+FROM ubuntu:18.04
+
+ENV USER="user"
+ENV HOME_DIR="/home/${USER}"
+ENV WORK_DIR="${HOME_DIR}/hostcwd" \
+    PATH="${HOME_DIR}/.local/bin:${PATH}"
+
+# configures locale
+RUN apt update -qq > /dev/null && \
+    apt install -qq --yes --no-install-recommends \
+    locales && \
+    locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
+# installs system dependencies (required to setup all the tools)
+RUN apt install -qq --yes --no-install-recommends \
+    sudo python-pip python-setuptools file
+
+# https://buildozer.readthedocs.io/en/latest/installation.html#android-on-ubuntu-18-04-64bit
+RUN dpkg --add-architecture i386 && apt update -qq > /dev/null && \
+	apt install -qq --yes --no-install-recommends \
+	build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
+	libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 \
+	python2.7-dev openjdk-8-jdk unzip zlib1g-dev zlib1g:i386
+
+# prepares non root env
+RUN useradd --create-home --shell /bin/bash ${USER}
+# with sudo access and no password
+RUN usermod -append --groups sudo ${USER}
+RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER ${USER}
+WORKDIR ${WORK_DIR}
+
+# installs buildozer and dependencies
+RUN pip install --user Cython==0.25.2 buildozer
+# calling buildozer adb command should trigger SDK/NDK first install and update
+# but it requires a buildozer.spec file
+RUN cd /tmp/ && buildozer init && buildozer android adb -- version && cd -
+# fixes source and target JDK version, refs https://github.com/kivy/buildozer/issues/625
+RUN sed s/'name="java.source" value="1.5"'/'name="java.source" value="7"'/ -i ${HOME_DIR}/.buildozer/android/platform/android-sdk-20/tools/ant/build.xml
+RUN sed s/'name="java.target" value="1.5"'/'name="java.target" value="7"'/ -i ${HOME_DIR}/.buildozer/android/platform/android-sdk-20/tools/ant/build.xml
+
+ENTRYPOINT ["buildozer"]

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,20 @@ The pip package does not yet support python3.
 #.  Please note the "android" buildozer target, and use that for any and all buildozer commands you run (even if the docs just say "android").
 
 
+Buildozer Docker image
+----------------------
+
+A Dockerfile is available to use buildozer through a Docker environment.
+
+#. Build with::
+
+    docker build --tag=buildozer .
+
+#. Run with::
+
+    docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+
+
 Examples of Buildozer commands:
 --------------------------------
 


### PR DESCRIPTION
Buildozer Dockerfile, fixes #589

Installs buildozer and dependencies, documents usage.

To build the image you first need to `cd` to where the `Dockerfile` is,
then run:
```sh
docker build --tag=buildozer .
```
Then you can use the container e.g. with:
```sh
docker run --volume "$(pwd)":/home/user/hostcwd buildozer --help
```
The above command mounts host current working directory in container using `--volume` option.
Also added workaround for #625