### PR TITLE
Changes how is_gradle_build is detected.

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -34,6 +34,7 @@ from shutil import copyfile
 from glob import glob
 
 from buildozer.libs.version import parse
+from distutils.version import LooseVersion
 
 
 class TargetAndroid(Target):
@@ -797,10 +798,13 @@ class TargetAndroid(Target):
             # maybe the hook fail because the apk is not
             pass
 
-        # XXX found how the apk name is really built from the title
+        build_tools_versions = os.listdir(join(self.android_sdk_dir, "build-tools"))
+        build_tools_versions = sorted(build_tools_versions, key=LooseVersion)
+        build_tools_version = build_tools_versions[-1]
         gradle_files = ["build.gradle", "gradle", "gradlew"]
-        is_gradle_build = any((
-            exists(join(dist_dir, x)) for x in gradle_files))
+        is_gradle_build = build_tools_version >= "25.0" and any(
+            (exists(join(dist_dir, x)) for x in gradle_files))
+
         if is_gradle_build:
             # on gradle build, the apk use the package name, and have no version
             packagename = config.get('app', 'package.name')


### PR DESCRIPTION
Prevents build step from failing.
Taken from https://github.com/kivy/buildozer/pull/691 (@gautam-kumar-22) to help push it along since it seems stuck.

Fixes #312, #597, #599, #603, #606, #613, #632, #636, #647, #649, #662