### PR TITLE
Improved error handling if p4a setup.py can't be read

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -523,8 +523,10 @@ class TargetAndroid(Target):
                 setup = fd.read()
                 deps = re.findall("install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[1]
                 deps = ast.literal_eval(deps)
-        except Exception:
-            deps = []
+        except IOError:
+            self.buildozer.error('Failed to read python-for-android setup.py at {}'.format(
+                join(self.pa_dir, 'setup.py')))
+            exit(1)
         pip_deps = []
         for dep in deps:
             pip_deps.append('"{}"'.format(dep))


### PR DESCRIPTION
If this file doesn't exist then there's probably no point attempting to continue, as buildozer's assumptions are automatically all messed up.

Also should not use `except Exception:`! I think this probably obscured an error someone reported on discord.