### PR TITLE
Allow for `install_reqs` line having whitespace at start.

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -521,7 +521,7 @@ class TargetAndroid(Target):
         try:
             with open(join(self.pa_dir, "setup.py")) as fd:
                 setup = fd.read()
-                deps = re.findall("^install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
+                deps = re.findall("^\*install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
                 deps = ast.literal_eval(deps)
         except IOError:
             self.buildozer.error('Failed to read python-for-android setup.py at {}'.format(

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -521,7 +521,7 @@ class TargetAndroid(Target):
         try:
             with open(join(self.pa_dir, "setup.py")) as fd:
                 setup = fd.read()
-                deps = re.findall("^\*install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
+                deps = re.findall("^\s*install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
                 deps = ast.literal_eval(deps)
         except IOError:
             self.buildozer.error('Failed to read python-for-android setup.py at {}'.format(


### PR DESCRIPTION
This fixes:
```
$ buildozer android debug
# Check configuration tokens
# Ensure build layout
# Check configuration tokens
# Preparing build
# Check requirements for android
# Install platform
Traceback (most recent call last):
  File "/usr/local/bin/buildozer", line 11, in <module>
    load_entry_point('buildozer==0.36.dev0', 'console_scripts', 'buildozer')()
  File "/usr/local/lib/python3.6/dist-packages/buildozer/scripts/client.py", line 13, in main
    Buildozer().run_command(sys.argv[1:])
  File "/usr/local/lib/python3.6/dist-packages/buildozer/__init__.py", line 1059, in run_command
    self.target.run_commands(args)
  File "/usr/local/lib/python3.6/dist-packages/buildozer/target.py", line 92, in run_commands
    func(args)
  File "/usr/local/lib/python3.6/dist-packages/buildozer/target.py", line 102, in cmd_debug
    self.buildozer.prepare_for_build()
  File "/usr/local/lib/python3.6/dist-packages/buildozer/__init__.py", line 176, in prepare_for_build
    self.target.install_platform()
  File "/usr/local/lib/python3.6/dist-packages/buildozer/targets/android.py", line 467, in install_platform
    self._install_p4a()
  File "/usr/local/lib/python3.6/dist-packages/buildozer/targets/android.py", line 524, in _install_p4a
    deps = re.findall("^install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
IndexError: list index out of range
```