### PR TITLE
Correctly write out a sub-process's `stdout` when using Python 3.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -311,7 +311,7 @@ class Buildozer(object):
                     ret_stdout.append(chunk)
                 if show_output:
                     if IS_PY3:
-                        stdout.write(str(chunk))
+                        stderr.write(chunk.decode('utf-8'))
                     else:
                         stdout.write(chunk)
             if fd_stderr in readx:


### PR DESCRIPTION
`stderr` was handled correctly but not `stdout`...