### PR TITLE
fix ndk URLs

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -744,7 +744,7 @@ class Buildozer(object):
 
         rmtree(self.app_dir)
 
-        for root, dirs, files in walk(source_dir):
+        for root, dirs, files in walk(source_dir, followlinks=True):
             # avoid hidden directory
             if True in [x.startswith('.') for x in root.split(sep)]:
                 continue

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -285,6 +285,13 @@ class TargetAndroid(Target):
         _version = re.search('(.+?)[a-z]', self.android_ndk_version).group(1)
 
         self.buildozer.info('Android NDK is missing, downloading')
+        # Welcome to the NDK URL hell!
+        # a list of all NDK URLs up to level 14 can be found here:
+        #  https://gist.github.com/roscopecoltran/43861414fbf341adac3b6fa05e7fad08
+        # it seems that from level 11 on the naming schema is consistent
+        # from 10e on the URLs can be looked up at 
+        # https://developer.android.com/ndk/downloads/older_releases
+
         if platform in ('win32', 'cygwin'):
             # Checking of 32/64 bits at Windows from: http://stackoverflow.com/a/1405971/798575
             import struct
@@ -292,14 +299,18 @@ class TargetAndroid(Target):
             is_64 = (8 * struct.calcsize("P") == 64)
 
         elif platform in ('darwin', ):
-            if int(_version) > 9:
+            if int(_version) >= '10e':
+                archive = 'android-ndk-r{0}-darwin-{1}.zip'
+            elif _version >= '10c':
                 archive = 'android-ndk-r{0}-darwin-{1}.bin'
             else:
                 archive = 'android-ndk-r{0}-darwin-{1}.tar.bz2'
             is_64 = (os.uname()[4] == 'x86_64')
 
         elif platform.startswith('linux'):
-            if int(_version) > 9:  # if greater than 9, take it as .bin file
+            if _version >='10e':
+                archive = 'android-ndk-r{0}-linux-{1}.zip'
+            elif _version >= '10c': 
                 archive = 'android-ndk-r{0}-linux-{1}.bin'
             else:
                 archive = 'android-ndk-r{0}-linux-{1}.tar.bz2'
@@ -311,7 +322,12 @@ class TargetAndroid(Target):
         unpacked = 'android-ndk-r{0}'
         archive = archive.format(self.android_ndk_version, architecture)
         unpacked = unpacked.format(self.android_ndk_version)
-        url = 'http://dl.google.com/android/ndk/'
+
+        if _version >= '10e':
+            url='https://dl.google.com/android/repository/'
+        else:
+            url = 'http://dl.google.com/android/ndk/'
+
         self.buildozer.download(url,
                                 archive,
                                 cwd=self.buildozer.global_platform_dir)


### PR DESCRIPTION
buildozer failed with downloading recent versions of android NDK.
This diff reflects the changes in the android NDK download urls.
I tested it with the recent NDKs (16b,17c).