### PR TITLE
Update cython version from the docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,7 +22,7 @@ Android on Ubuntu 18.04 (64bit)
 
 ::
 
-    sudo pip install --upgrade cython==0.21
+    sudo pip install --upgrade cython==0.28.6
     sudo dpkg --add-architecture i386
     sudo apt update
     sudo apt install build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python2.7-dev openjdk-8-jdk unzip zlib1g-dev zlib1g:i386


### PR DESCRIPTION
`cython==0.28.6` seems to be doing just fine on p4a until now.
https://github.com/kivy/python-for-android/blob/df60061/Dockerfile#L120