### PR TITLE
allow specifying of Android NDK API. Resolves #758

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -99,7 +99,7 @@ fullscreen = 0
 # (str) Android NDK version to use
 #android.ndk = 9c
 
-# (int) Android NDK API to use (optional). This is the minimum API your API will support. 
+# (int) Android NDK API to use (optional). This is the minimum API your app will support. 
 #android.ndk.api = 19
 
 # (bool) Use --private data storage (True) or --dir public storage (False)

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -90,7 +90,7 @@ fullscreen = 0
 # (int) Android API to use
 #android.api = 19
 
-# (int) Minimum API required
+# (int) Minimum API required. You will need to set the android.ndk.api to be as low as this value.
 #android.minapi = 9
 
 # (int) Android SDK version to use
@@ -99,7 +99,7 @@ fullscreen = 0
 # (str) Android NDK version to use
 #android.ndk = 9c
 
-# (int) Android NDK API to use (optional)
+# (int) Android NDK API to use (optional). This is the minimum API your API will support. 
 #android.ndk.api = 19
 
 # (bool) Use --private data storage (True) or --dir public storage (False)

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -100,7 +100,7 @@ fullscreen = 0
 #android.ndk = 9c
 
 # (int) Android NDK API to use (optional). This is the minimum API your app will support. 
-#android.ndk.api = 19
+#android.ndk_api = 19
 
 # (bool) Use --private data storage (True) or --dir public storage (False)
 #android.private_storage = True

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -99,6 +99,9 @@ fullscreen = 0
 # (str) Android NDK version to use
 #android.ndk = 9c
 
+# (int) Android NDK API to use (optional)
+#android.ndk.api = 19
+
 # (bool) Use --private data storage (True) or --dir public storage (False)
 #android.private_storage = True
 

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -29,6 +29,9 @@ class TargetAndroidNew(TargetAndroid):
         color = 'always' if USE_COLOR else 'never'
         self.extra_p4a_args = ' --color={} --storage-dir="{}"'.format(
             color, self._build_dir)
+        ndk_api = self.buildozer.config.getdefault('app', 'android.ndk.api', None)
+        if ndk_api is not None:
+            self.extra_p4a_args += ' --ndk-api={}'.format(ndk_api)
         hook = self.buildozer.config.getdefault("app", "p4a.hook", None)
         if hook is not None:
             self.extra_p4a_args += ' --hook={}'.format(realpath(hook))

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -29,7 +29,7 @@ class TargetAndroidNew(TargetAndroid):
         color = 'always' if USE_COLOR else 'never'
         self.extra_p4a_args = ' --color={} --storage-dir="{}"'.format(
             color, self._build_dir)
-        ndk_api = self.buildozer.config.getdefault('app', 'android.ndk.api', None)
+        ndk_api = self.buildozer.config.getdefault('app', 'android.ndk_api', None)
         if ndk_api is not None:
             self.extra_p4a_args += ' --ndk-api={}'.format(ndk_api)
         hook = self.buildozer.config.getdefault("app", "p4a.hook", None)


### PR DESCRIPTION
This will let us specify the NDK API, which will allow us to create an .apk that has a min API of 19 (or lower?) while still allowing the targeting of higher API levels, like 27. 

Adds a new entry to the buildozer spec as well.  Resolves #758 