### PR TITLE
Fixed download url for ndk versions < 11

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -313,7 +313,10 @@ class TargetAndroid(Target):
         unpacked = 'android-ndk-r{0}'
         archive = archive.format(self.android_ndk_version, architecture)
         unpacked = unpacked.format(self.android_ndk_version)
-        url = 'http://dl.google.com/android/repository/'
+        if int(self.android_ndk_version[:-1]) >= 11:
+            url = 'http://dl.google.com/android/repository/'
+        else:
+            url = 'http://dl.google.com/android/ndk/'
         self.buildozer.download(url,
                                 archive,
                                 cwd=self.buildozer.global_platform_dir)


### PR DESCRIPTION
The URL for ndk versions < 11 doesn't work anymore.
I've found a complete listing for direct links and verified that they work here http://pnsurez.blogspot.com/2015/07/download-android-ndk-tools.html
It was troublesome because the default 9c ndk wasn't downloading.