### PR TITLE
Docker from current git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
 # Dockerfile for providing buildozer
 # Build with:
 # docker build --tag=buildozer .
+# 
+# if you want to use bleeding edge/current version from git, instead from pypi, then use
+# docker build --tag=buildozer --build-arg git=true .
+#
 # In order to give the container access to your current working directory
 # it must be mounted using the --volume option.
 # Run with (e.g. `buildozer --version`):
 # docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
 # Or for interactive shell:
 # docker run --volume "$(pwd)":/home/user/hostcwd --entrypoint /bin/bash -it --rm buildozer
-FROM ubuntu:18.04
 
+FROM ubuntu:18.04
+ARG git
+
+ENV BDOZER_REQ=${git:+"/src"}
+ENV BDOZER_REQ=${BDOZER_REQ:-"buildozer"}
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
 ENV WORK_DIR="${HOME_DIR}/hostcwd" \
     PATH="${HOME_DIR}/.local/bin:${PATH}"
+
+COPY . /src
 
 # configures locale
 RUN apt update -qq > /dev/null && \
@@ -44,7 +54,8 @@ USER ${USER}
 WORKDIR ${WORK_DIR}
 
 # installs buildozer and dependencies
-RUN pip install --user Cython==0.25.2 buildozer
+RUN pip install --user Cython==0.25.2 $BDOZER_REQ
+
 # calling buildozer adb command should trigger SDK/NDK first install and update
 # but it requires a buildozer.spec file
 RUN cd /tmp/ && buildozer init && buildozer android adb -- version && cd -

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(
     license='MIT',
     packages=[
         'buildozer', 'buildozer.targets', 'buildozer.libs', 'buildozer.scripts'
-    ],
+        ],
     package_data={'buildozer': ['default.spec']},
     include_package_data=True,
-    install_requires=['pexpect', 'virtualenv'],
+    install_requires=['pexpect', 'virtualenv', 'sh'],
     classifiers=[
         'Development Status :: 4 - Beta', 'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',


### PR DESCRIPTION
it's nice to build docker with current, bleeding edge or even uncommited version of buildozer, instead of using only stable, pypi pushed buildozer version. 

In such case, --build-arg git=true should be used. 