### PR TITLE
Fixes ndk url in current buildozer #778 #760  #767

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -313,7 +313,7 @@ class TargetAndroid(Target):
         unpacked = 'android-ndk-r{0}'
         archive = archive.format(self.android_ndk_version, architecture)
         unpacked = unpacked.format(self.android_ndk_version)
-        url = 'http://dl.google.com/android/repository/'
+        url = 'http://dl.google.com/android/ndk/'
         self.buildozer.download(url,
                                 archive,
                                 cwd=self.buildozer.global_platform_dir)


### PR DESCRIPTION
Currently kivy will not build any modern app, unless the url is fixed.

This has been stuck for a while. And reported many times. See #778 #760  #767
Also see: https://stackoverflow.com/questions/42097586/buildozer-android-ndk-not-downloading-ubuntu

There also seem to be pull requests about this that have been ignored, so I suggest if this pull request is not merged, please direct me how to make it so it would get merged and people people following kivy tutorials don't reach dead ends.