### PR TITLE
Fix missing requirements: sh package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER ${USER}
 WORKDIR ${WORK_DIR}
 
 # installs buildozer and dependencies
-RUN pip install --user Cython==0.25.2 $BDOZER_REQ
+RUN pip install --user Cython==0.25.2 sh $BDOZER_REQ
 
 # calling buildozer adb command should trigger SDK/NDK first install and update
 # but it requires a buildozer.spec file


### PR DESCRIPTION
Pull request for fix missing requirements.

Build under docker, have error:

```
File buildozer.spec created, ready to customize!
Traceback (most recent call last):
  File "/home/user/.local/bin/buildozer", line 11, in <module>
# Check configuration tokens
    sys.exit(main())
  File "/home/user/.local/lib/python2.7/site-packages/buildozer/scripts/client.py", line 13, in main
    Buildozer().run_command(sys.argv[1:])
  File "/home/user/.local/lib/python2.7/site-packages/buildozer/__init__.py", line 1053, in run_command
    targets = [x[0] for x in self.targets()]
  File "/home/user/.local/lib/python2.7/site-packages/buildozer/__init__.py", line 945, in targets
    fromlist=['buildozer'])
  File "/home/user/.local/lib/python2.7/site-packages/buildozer/targets/android.py", line 28, in <module>
    import sh
ImportError: No module named sh
```