### PR TITLE
Specify GitHub branches in buildozer.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -220,6 +220,16 @@ android.arch = armeabi-v7a
 
 # (str) Path to a custom kivy-ios folder
 #ios.kivy_ios_dir = ../kivy-ios
+# Alternately, specify the URL and branch of a git checkout:
+ios.kivy_ios_url = https://github.com/kivy/kivy-ios
+ios.kivy_ios_branch = master
+
+# Another platform dependency: ios-deploy
+# Uncomment to use a custom checkout
+#ios.ios_deploy_dir = ../ios_deploy
+# Or specify URL and branch
+ios.ios_deploy_url = https://github.com/phonegap/ios-deploy
+ios.ios_deploy_branch = 1.7.0
 
 # (str) Name of the certificate to use for signing the debug version
 # Get a list of available identities: buildozer ios list_identities

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -147,3 +147,119 @@ class Target(object):
 
     def cmd_serve(self, *args):
         self.buildozer.cmd_serve()
+
+    def path_or_git_url(self, repo, owner='kivy', branch='master',
+                        url_format='https://github.com/{owner}/{repo}.git',
+                        platform=None,
+                        squash_hyphen=True):
+        """Get source location for a git checkout
+
+        This method will check the `buildozer.spec` for the keys:
+            {repo}_dir
+            {repo}_url
+            {repo}_branch
+
+        and use them to determine the source location for a git checkout.
+
+        If a `platform` is specified, {platform}.{repo} will be used
+        as the base for the buildozer key
+
+        `{repo}_dir` specifies a custom checkout location
+        (relative to `buildozer.root_dir`). If present, `path` will be
+        set to this value and `url`, `branch` will be set to None,
+        None. Otherwise, `{repo}_url` and `{repo}_branch` will be
+        examined.
+
+        If no keys are present, the kwargs will be used to create
+        a sensible default URL and branch.
+
+        :Parameters:
+            `repo`: str (required)
+                name of repository to fetch. Used both for buildozer
+                keys ({platform}.{repo}_dir|_url|_branch) and in building
+                default git URL
+            `branch`: str (default 'master')
+                Specific branch to retrieve if none specified in
+                buildozer.spec.
+            `owner`: str
+                owner of repo.
+            `platform`: str or None
+                platform prefix to use when retrieving `buildozer.spec`
+                keys. If specified, key names will be {platform}.{repo}
+                instead of just {repo}
+            `squash_hyphen`: boolean
+                if True, change '-' to '_' when looking for
+                keys in buildozer.spec. This lets us keep backwards
+                compatibility with old buildozer.spec files
+            `url_format`: format string
+                Used to construct default git URL.
+                can use {repo} {owner} and {branch} if needed.
+
+        :Returns:
+            A Tuple (path, url, branch) where
+                `path`
+                    Path to a custom git checkout. If specified,
+                    both `url` and `branch` will be None
+                `url`
+                    URL of git repository from where code should be
+                    checked-out
+                `branch`
+                    branch name (or tag) that should be used for the
+                    check-out.
+
+        """
+        if squash_hyphen:
+            key = repo.replace('-', '_')
+        else:
+            key = repo
+        if platform:
+            key = "{}.{}".format(platform, key)
+        config = self.buildozer.config
+        path = config.getdefault('app', '{}_dir'.format(key), None)
+
+        if path is not None:
+            path = join(self.buildozer.root_dir, path)
+            url = None
+            branch = None
+        else:
+            branch = config.getdefault('app', '{}_branch'.format(key), branch)
+            default_url = url_format.format(owner=owner, repo=repo, branch=branch)
+            url = config.getdefault('app', '{}_url'.format(key), default_url)
+            if branch != 'master':
+                url = "--branch {} {}".format(branch, url)
+        return path, url, branch
+
+    def install_or_update_repo(self, repo, **kwargs):
+        """Install or update a git repository into the platform directory.
+
+        This will clone the contents of a git repository to
+        `buildozer.platform_dir`. The location of this repo can be
+        speficied via URL and branch name, or via a custom (local)
+        directory name.
+
+        :Parameters:
+            **kwargs:
+                Any valid arguments for :meth:`path_or_git_url`
+
+        :Returns:
+            fully qualified path to updated git repo
+        """
+        if platform is None:
+            raise Exception("platform is a required keyword argument")
+        cmd = self.buildozer.cmd
+        install_dir = join(self.buildozer.platform_dir, repo)
+        custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, platform=platform, **kwargs)
+        if not self.buildozer.file_exists(install_dir):
+            if custom_dir:
+                cmd('mkdir -p "{}"'.format(install_dir))
+                cmd('cp -a "{}"/* "{}"/'.format(custom_dir, install_dir))
+            else:
+                cmd('git clone {}'.format(clone_url),
+                        cwd=self.buildozer.platform_dir)
+        elif self.platform_update:
+            if custom_dir:
+                cmd('cp -a "{}"/* "{}"/'.format(custom_dir, install_dir))
+            else:
+                cmd('git clean -dxf', cwd=install_dir)
+                cmd('git pull origin {}'.format(clone_branch), cwd=install_dir)
+        return install_dir

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -1,6 +1,6 @@
 from sys import exit
 import os
-
+from os.path import join
 
 def no_config(f):
     f.__no_config = True
@@ -244,11 +244,9 @@ class Target(object):
         :Returns:
             fully qualified path to updated git repo
         """
-        if platform is None:
-            raise Exception("platform is a required keyword argument")
         cmd = self.buildozer.cmd
         install_dir = join(self.buildozer.platform_dir, repo)
-        custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, platform=platform, **kwargs)
+        custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, **kwargs)
         if not self.buildozer.file_exists(install_dir):
             if custom_dir:
                 cmd('mkdir -p "{}"'.format(install_dir))

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -91,30 +91,11 @@ class TargetIos(Target):
         self.buildozer.debug(' -> found {0}'.format(xcode))
 
     def install_platform(self):
-        cmd = self.buildozer.cmd
-        self.ios_dir = ios_dir = join(self.buildozer.platform_dir, 'kivy-ios')
-        custom_kivy_ios = self.buildozer.config.getdefault('app', 'ios.kivy_ios_dir')
-        if custom_kivy_ios:
-            custom_kivy_ios = join(self.buildozer.root_dir, custom_kivy_ios)
-        if not self.buildozer.file_exists(ios_dir):
-            if custom_kivy_ios:
-                cmd('mkdir -p "{}"'.format(ios_dir))
-                cmd('cp -a "{}"/* "{}"/'.format(custom_kivy_ios, ios_dir))
-            else:
-                cmd('git clone https://github.com/kivy/kivy-ios',
-                        cwd=self.buildozer.platform_dir)
-        elif self.platform_update:
-            if custom_kivy_ios:
-                cmd('cp -a "{}"/* "{}"/'.format(custom_kivy_ios, ios_dir))
-            else:
-                cmd('git clean -dxf', cwd=ios_dir)
-                cmd('git pull origin master', cwd=ios_dir)
-
-        self.ios_deploy_dir = ios_deploy_dir = join(self.buildozer.platform_dir,
-                'ios-deploy')
-        if not self.buildozer.file_exists(ios_deploy_dir):
-            cmd('git clone --branch 1.7.0 https://github.com/phonegap/ios-deploy',
-                    cwd=self.buildozer.platform_dir)
+        self.ios_dir = self.install_or_update_repo('kivy-ios', platform='ios')
+        self.ios_deploy_dir = self.install_or_update_repo('ios-deploy',
+                                                          platform='ios',
+                                                          branch='1.7.0',
+                                                          owner='phonegap')
 
     def get_available_packages(self):
         available_modules = self.buildozer.cmd(


### PR DESCRIPTION
Currently (for an iOS build) buildozer downloads 2 platform build dependencies from github repos:
* kivy-ios
* ios-deploy

This change allows the repo/branch of those dependencies to be specified in `buildozer.spec`, either as local (custom) checkouts, or by specifying a git URL and branch. In fact, it allows any git-based dependency to be handled in the same manner, either by specifying a local checkout directory to use, or by specifying a URL/branch pair.

This has been essential for me in order to lock the versions of upstream dependencies during periods of high code churn (or to refer my build to forked, bug-fixed repos of these upstream dependencies)

`buildozer.spec` can now be used to specify the location of these repos as follows:

```
# Uncomment the following line to use the local check-out to install `kivy-ios`
# If specified, this overrides any choice of url/branch below
# ios.kivy_ios_dir = ../kivy-ios

# uncomment the following lines to specify a custom (forked) kivy-ios repo/branch
# specifying no branch will default to using master
ios.kivy_ios_url = https://github.com/learnleapfly/kivy-ios
ios.kivy_ios_branch = fix_py2
```

This mechanism is platform agnostic, so I have moved the helper functions to be methods of `Target` rather than `TargetIos`.  I'm not sure if p4a handles platform dependencies by checking out git repos at present.