### PR TITLE
Fix python 2 crash when reading config file

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -119,7 +119,10 @@ class Buildozer(object):
         self.config.getrawdefault = self._get_config_raw_default
 
         if exists(filename):
-            self.config.read(filename, "utf-8")
+            try:
+                self.config.read(filename, "utf-8")
+            except TypeError:  # python 2 has no second arg here
+                self.config.read(filename)
             self.check_configuration_tokens()
 
         # Check all section/tokens for env vars, and replace the


### PR DESCRIPTION
Fix python 2 crash when reading config file, also see https://github.com/kivy/buildozer/commit/c66af5dc0bf7420df6d71c26bee55f085b80c93b#commitcomment-31965387