### PR TITLE
- store cache about ~/.buildozer in ~/.buildozer and cache about .bui…

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -463,6 +463,7 @@ class Buildozer(object):
         self.mkdir(self.bin_dir)
 
         self.mkdir(self.applibs_dir)
+        self.global_state = JsonStore(join(self.global_buildozer_dir, 'state.db'))
         self.state = JsonStore(join(self.buildozer_dir, 'state.db'))
 
         target = self.targetname

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -417,7 +417,7 @@ class TargetAndroid(Target):
             self.android_api, self.android_minapi, self.android_ndk_version,
             self.android_sdk_dir, self.android_ndk_dir
         ]
-        if self.buildozer.state.get(cache_key, None) == cache_value:
+        if self.buildozer.global_state.get(cache_key, None) == cache_value:
             return True
 
         # 3 pass installation.
@@ -485,8 +485,8 @@ class TargetAndroid(Target):
 
         self.buildozer.info('Android packages installation done.')
 
-        self.buildozer.state[cache_key] = cache_value
-        self.buildozer.state.sync()
+        self.buildozer.global_state[cache_key] = cache_value
+        self.buildozer.global_state.sync()
 
     def _check_aidl(self, v_build_tools):
         self.buildozer.debug('Check that aidl can be executed')


### PR DESCRIPTION
- store cache about ~/.buildozer in ~/.buildozer and cache about .buildozer in .buildozer

While hacking in buildozer, I discovered that cache in local .buildozer dir stores information about state of ~/.buildozer

It leads to situation, that when you remove local .buildozer file, in next buildozer run whole SDK and NDK (huge downloads) is downloaded again. 

Also, it's possible that if you remove ~/.buildozer, then local cache still things that everything is still in ~/.buildozer and build fails. 

This PR splits the cache. 

