### PR TITLE
Update for p4a master

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -87,20 +87,20 @@ fullscreen = 0
 # (list) Permissions
 #android.permissions = INTERNET
 
-# (int) Android API to use
-#android.api = 19
+# (int) Target Android API, should be as high as possible.
+#android.api = 27
 
-# (int) Minimum API required. You will need to set the android.ndk_api to be as low as this value.
-#android.minapi = 9
+# (int) Minimum API your APK will support.
+#android.minapi = 21
 
 # (int) Android SDK version to use
 #android.sdk = 20
 
 # (str) Android NDK version to use
-#android.ndk = 9c
+#android.ndk = 17c
 
-# (int) Android NDK API to use (optional). This is the minimum API your app will support. 
-#android.ndk_api = 19
+# (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
+#android.ndk_api = 21
 
 # (bool) Use --private data storage (True) or --dir public storage (False)
 #android.private_storage = True

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -152,8 +152,8 @@ fullscreen = 0
 # (list) Java classes to add as activities to the manifest.
 #android.add_activites = com.example.ExampleActivity
 
-# (str) python-for-android branch to use, defaults to stable
-#p4a.branch = stable
+# (str) python-for-android branch to use, defaults to master
+#p4a.branch = master
 
 # (str) OUYA Console category. Should be one of GAME or APP
 # If you leave this blank, OUYA support will not be enabled

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -14,10 +14,10 @@ if sys.platform == 'win32':
 from platform import uname
 WSL = 'Microsoft' in uname()[2]
 
-ANDROID_API = '19'
-ANDROID_MINAPI = '9'
+ANDROID_API = '27'
+ANDROID_MINAPI = '21'
 ANDROID_SDK_VERSION = '20'
-ANDROID_NDK_VERSION = '9c'
+ANDROID_NDK_VERSION = '17c'
 APACHE_ANT_VERSION = '1.9.4'
 
 import traceback

--- a/buildozer/targets/android_new.py
+++ b/buildozer/targets/android_new.py
@@ -13,7 +13,7 @@ from os.path import join, expanduser, realpath
 
 class TargetAndroidNew(TargetAndroid):
     targetname = 'android'
-    p4a_branch = "stable"
+    p4a_branch = "master"
     p4a_directory = "python-for-android-new-toolchain"
     p4a_apk_cmd = "apk --debug --bootstrap="
     extra_p4a_args = ''


### PR DESCRIPTION
With these changes, buildozer defaults to using python-for-android's master branch, and with the next defaults will compile successfully.