### PR TITLE
fix: drop release-unsigned from release output path

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1005,8 +1005,10 @@ class TargetAndroid(Target):
         if self.build_mode == 'debug':
             build_cmd += [("debug", )]
             mode = 'debug'
+            mode_sign = mode
         else:
             build_cmd += [("release", )]
+            mode_sign = "release"
             mode = self.get_release_mode()
 
         self.execute_build_package(build_cmd)
@@ -1031,7 +1033,7 @@ class TargetAndroid(Target):
             packagename = config.get('app', 'package.name')
             apk = u'{packagename}-{mode}.apk'.format(
                 packagename=packagename, mode=mode)
-            apk_dir = join(dist_dir, "build", "outputs", "apk", mode)
+            apk_dir = join(dist_dir, "build", "outputs", "apk", mode_sign)
             apk_dest = u'{packagename}-{version}-{mode}.apk'.format(
                 packagename=packagename, mode=mode, version=version)
 


### PR DESCRIPTION
Guessing based on this logoutput
```
[INFO]:    # Copying APK to current directory
[INFO]:    # APK filename not found in build output. Guessing...
[INFO]:    # Found APK file: /home/data/.buildozer/android/platform/build/dists/zeronet/build/outputs/apk/release/zeronet-release-unsigned.apk
[INFO]:    # Add version number to APK
[INFO]:    # APK renamed to zeronet-0.6.5.1-release-unsigned.apk
[DEBUG]:   -> running cp /home/data/.buildozer/android/platform/build/dists/zeronet/build/outputs/apk/release/zeronet-release-unsigned.apk zeronet-0.6.5.1-release-unsigned.apk
...
IOError: [Errno 2] No such file or directory: u'/home/data/.buildozer/android/platform/build/dists/zeronet/build/outputs/apk/release-unsigned/zeronet-release-unsigned.apk'
```