### PR TITLE
feat: make unzip quiet

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -661,7 +661,7 @@ class Buildozer(object):
             return
 
         if archive.endswith('.zip'):
-            self.cmd('unzip {}'.format(join(cwd, archive)), cwd=cwd)
+            self.cmd('unzip -q {}'.format(join(cwd, archive)), cwd=cwd)
             return
 
         raise Exception('Unhandled extraction for type {0}'.format(archive))


### PR DESCRIPTION
I don't think the list of all files that unzip has extracted is really of any use.

At least for the NDK the amount of stuff it logs is huge.