### PR TITLE
add missing android arch to spec file

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -197,7 +197,7 @@ fullscreen = 0
 # (bool) Copy library instead of making a libpymodules.so
 #android.copy_libs = 1
 
-# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86
+# (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 android.arch = armeabi-v7a
 
 #


### PR DESCRIPTION
x86_64 was missing from the choices in the spec file.