### PR TITLE
Removes extra log_env() call

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -295,7 +295,6 @@ class Buildozer(object):
             else:
                 self.debug('Run {0!r} ...'.format(command.split()[0]))
         self.debug('Cwd {}'.format(kwargs.get('cwd')))
-        self.log_env(self.DEBUG, kwargs["env"])
 
         # open the process
         if sys.platform == 'win32':


### PR DESCRIPTION
Don't print all environment variables for every single cmd() call, refs:
https://github.com/kivy/buildozer/pull/802/files#r261844323
Leaves only one `log_env()` call on command failed.