### PR TITLE
Updates system requirements needed to build recipes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
 # Dockerfile for providing buildozer
+#
 # Build with:
-# docker build --tag=buildozer .
+# docker build --tag=kivy/buildozer .
 # 
 # In order to give the container access to your current working directory
 # it must be mounted using the --volume option.
 # Run with (e.g. `buildozer --version`):
-# docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+# docker run \
+#   --volume "$HOME/.buildozer":/home/user/.buildozer \
+#   --volume "$(pwd)":/home/user/hostcwd \
+#   kivy/buildozer --version
+#
 # Or for interactive shell:
-# docker run --volume "$(pwd)":/home/user/hostcwd --entrypoint /bin/bash -it --rm buildozer
+# docker run --interactive --tty --rm \
+#   --volume "$HOME/.buildozer":/home/user/.buildozer \
+#   --volume "$(pwd)":/home/user/hostcwd \
+#   --entrypoint /bin/bash \
+#   kivy/buildozer
+#
+# If you get a `PermissionError` on `/home/user/.buildozer/cache`,
+# try updating the permissions from the host with:
+# sudo chown $USER -R ~/.buildozer
+# Or simply recreate the directory from the host with:
+# rm -rf ~/.buildozer && mkdir ~/.buildozer
 
 FROM ubuntu:18.04
 
@@ -26,16 +41,28 @@ ENV LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8"
 
-# installs system dependencies (required to setup all the tools)
+# system requirements to build most of the recipes
 RUN apt install -qq --yes --no-install-recommends \
-    sudo python3-pip python3-setuptools file
-
-# https://buildozer.readthedocs.io/en/latest/installation.html#android-on-ubuntu-18-04-64bit
-RUN dpkg --add-architecture i386 && apt update -qq > /dev/null && \
-	apt install -qq --yes --no-install-recommends \
-	build-essential ccache git libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 \
-	libpangox-1.0-0:i386 libpangoxft-1.0-0:i386 libidn11:i386 python2.7 python3 \
-	python3-dev openjdk-8-jdk unzip zlib1g-dev zlib1g:i386
+    autoconf \
+    automake \
+    build-essential \
+    ccache \
+    cmake \
+    gettext \
+    git \
+    libffi-dev \
+    libltdl-dev \
+    libtool \
+    openjdk-8-jdk \
+    patch \
+    pkg-config \
+    python2.7 \
+    python3-pip \
+    python3-setuptools \
+    sudo \
+    unzip \
+    zip \
+    zlib1g-dev
 
 # prepares non root env
 RUN useradd --create-home --shell /bin/bash ${USER}


### PR DESCRIPTION
Makes it possible to build Android APKs directly from Docker.
Tested by building sucessfully both:

  * kivy-garden/garden.zbarcam (20190303)
  * AndreMiras/EtherollApp (20190217)

After building the image with:
```
docker build --tag=kivy/buildozer .
```
The following command was used to build the Android APK:
```
docker run \
    --volume "$HOME/.buildozer":/home/user/.buildozer \
    --volume "$(pwd)":/home/user/hostcwd \
    kivy/buildozer android debug
```

Note the system dependencies were also sorted alphabetical to ease maintenance.
Later more dependencies can be added if needed to build a given recipe.