### PR TITLE
Handles unknown command/target error gracefully, closes #812

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@
 # Run with (e.g. `buildozer --version`):
 # docker run \
 #   --volume "$HOME/.buildozer":/home/user/.buildozer \
-#   --volume "$(pwd)":/home/user/hostcwd \
+#   --volume "$PWD":/home/user/hostcwd \
 #   kivy/buildozer --version
 #
 # Or for interactive shell:
 # docker run --interactive --tty --rm \
 #   --volume "$HOME/.buildozer":/home/user/.buildozer \
-#   --volume "$(pwd)":/home/user/hostcwd \
+#   --volume "$PWD":/home/user/hostcwd \
 #   --entrypoint /bin/bash \
 #   kivy/buildozer
 #

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -1056,7 +1056,7 @@ class Buildozer(object):
         # maybe it's a target?
         targets = [x[0] for x in self.targets()]
         if command not in targets:
-            print('Unknown command/target {}'.format(self.translate_target(command, inverse=True)))
+            print('Unknown command/target {}'.format(command))
             exit(1)
 
         self.set_target(command)

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -59,16 +59,16 @@ class TestBuildozer(unittest.TestCase):
         Basic test making sure the Buildozer object can be instanciated.
         """
         buildozer = Buildozer()
-        self.assertEqual(buildozer.specfilename, 'buildozer.spec')
+        assert buildozer.specfilename == 'buildozer.spec'
         # spec file doesn't have to exist
-        self.assertFalse(os.path.exists(buildozer.specfilename))
+        assert os.path.exists(buildozer.specfilename) is False
 
     def test_buildozer_read_spec(self):
         """
         Initializes Buildozer object from existing spec file.
         """
         buildozer = Buildozer(filename=self.default_specfile_path())
-        self.assertTrue(os.path.exists(buildozer.specfilename))
+        assert os.path.exists(buildozer.specfilename) is True
 
     def test_buildozer_help(self):
         """
@@ -78,7 +78,7 @@ class TestBuildozer(unittest.TestCase):
         buildozer = Buildozer()
         with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
             buildozer.usage()
-        self.assertIn('Usage:', mock_stdout.getvalue())
+        assert 'Usage:' in mock_stdout.getvalue()
 
     def test_log_get_set(self):
         """
@@ -121,3 +121,16 @@ class TestBuildozer(unittest.TestCase):
         assert 'debug message' in mock_stdout.getvalue()
         assert 'info message' in mock_stdout.getvalue()
         assert 'error message' in mock_stdout.getvalue()
+
+    def test_run_command_unknown(self):
+        """
+        Makes sure the unknown command/target is handled gracefully, refs:
+        https://github.com/kivy/buildozer/issues/812
+        """
+        buildozer = Buildozer()
+        command = 'foobar'
+        args = [command, 'debug']
+        with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            with self.assertRaises(SystemExit):
+                buildozer.run_command(args)
+        assert mock_stdout.getvalue() == 'Unknown command/target {}\n'.format(command)


### PR DESCRIPTION
Running `buildozer unknown_command` should show a meaningful error and exit. Fixes regression introduced in 4936d31 and adds unit tests.

Also updates other tests `assert` keyword rather than `self.assert*` in order to keep style consistent.

Last, minor `Dockerfile` documentation update as per recent @tshirtman feedback.