### PR TITLE
Download Apache ANT at the same path as the buildozer.spec android.ant_path option

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -290,14 +290,17 @@ class TargetAndroid(Target):
             self.buildozer.info('Apache ANT found at {0}'.format(ant_dir))
             return ant_dir
 
+        if not os.path.exists(ant_dir):
+            os.makedirs(ant_dir)
+
         self.buildozer.info('Android ANT is missing, downloading')
         archive = 'apache-ant-{0}-bin.tar.gz'.format(APACHE_ANT_VERSION)
         url = 'http://archive.apache.org/dist/ant/binaries/'
         self.buildozer.download(url,
                                 archive,
-                                cwd=self.buildozer.global_platform_dir)
+                                cwd=ant_dir)
         self.buildozer.file_extract(archive,
-                                    cwd=self.buildozer.global_platform_dir)
+                                    cwd=ant_dir)
         self.buildozer.info('Apache ANT installation done.')
         return ant_dir
 

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -8,6 +8,8 @@ from buildozer import Buildozer
 from six import StringIO
 import tempfile
 
+from buildozer.targets.android import TargetAndroid
+
 
 class TestBuildozer(unittest.TestCase):
 
@@ -134,3 +136,25 @@ class TestBuildozer(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 buildozer.run_command(args)
         assert mock_stdout.getvalue() == 'Unknown command/target {}\n'.format(command)
+
+    def test_android_ant_path(self):
+        """
+        Verify that the selected ANT path is being used from the spec file
+        """
+        my_ant_path = '/my/ant/path'
+
+        buildozer = Buildozer(filename=self.default_specfile_path(), target='android')
+        buildozer.config.set('app', 'android.ant_path', my_ant_path)  # Set ANT path
+        target = TargetAndroid(buildozer=buildozer)
+
+        # Mock first run
+        with mock.patch('buildozer.Buildozer.download') as download, \
+                mock.patch('buildozer.Buildozer.file_extract') as extract_file, \
+                mock.patch('os.makedirs'):
+            ant_path = target._install_apache_ant()
+            assert ant_path == my_ant_path
+
+        # Mock ant already installed
+        with mock.patch.object(Buildozer, 'file_exists', return_value=True):
+            ant_path = target._install_apache_ant()
+            assert ant_path == my_ant_path


### PR DESCRIPTION
ANT installation path was hardcoded so if you changed the installation path, it will download every time you run `buildozer android XXX`
```
# Android ANT is missing, downloading
# Downloading http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.4-bin.tar.gz
# Run 'tar xzf apache-ant-1.9.4-bin.tar.gz'
# Cwd /home/roberto/.buildozer/android/platform
# Apache ANT installation done.
```

I am sorry, I did not found any easy way to test this change since it will download ANT which we don't want that on testing