### PR TITLE
Made sure to print all lines of license question by always flushing

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -342,8 +342,8 @@ class Buildozer(object):
                     else:
                         stderr.write(chunk)
 
-        stdout.flush()
-        stderr.flush()
+            stdout.flush()
+            stderr.flush()
 
         process.communicate()
         if process.returncode != 0 and break_on_error:


### PR DESCRIPTION
Flushing on every output line seems to guarantee that the 'Accept [y/N]' line is printed. As far as I can see there's no reason not to do this.

This fixes the issue where the license text is shown, but then buildozer hangs without actually showing the line asking the user to press `y`.