### PR TITLE
disable orientation and window option for service_only bootstrap

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -981,16 +981,17 @@ class TargetAndroid(Target):
             build_cmd += [("--ouya-icon", join(self.buildozer.root_dir,
                                                ouya_icon))]
 
-        # add orientation
-        orientation = config.getdefault('app', 'orientation', 'landscape')
-        if orientation == 'all':
-            orientation = 'sensor'
-        build_cmd += [("--orientation", orientation)]
+        if config.getdefault('app','p4a.bootstrap','sdl2') != 'service_only':
+            # add orientation
+            orientation = config.getdefault('app', 'orientation', 'landscape')
+            if orientation == 'all':
+                orientation = 'sensor'
+            build_cmd += [("--orientation", orientation)]
 
-        # fullscreen ?
-        fullscreen = config.getbooldefault('app', 'fullscreen', True)
-        if not fullscreen:
-            build_cmd += [("--window", )]
+            # fullscreen ?
+            fullscreen = config.getbooldefault('app', 'fullscreen', True)
+            if not fullscreen:
+                build_cmd += [("--window", )]
 
         # wakelock ?
         wakelock = config.getbooldefault('app', 'android.wakelock', False)


### PR DESCRIPTION
buildozer had a glitch when building for 'service_only' bootstrap: it generated --window and --orientation parameters for the apk command which are not supported by the service_only bootstrap.
Together with kivy/python-for-android#1725 service_only can now be built with buildozer.