### PR TITLE
customizability options

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -128,6 +128,9 @@ fullscreen = 0
 # (str) Android entry point, default is ok for Kivy-based app
 #android.entrypoint = org.renpy.android.PythonActivity
 
+# (str) Android app theme, default is ok for Kivy-based app
+# android.apptheme = "@android:style/Theme.NoTitleBar"
+
 # (list) Pattern to whitelist for the whole project
 #android.whitelist =
 
@@ -154,6 +157,23 @@ fullscreen = 0
 # (list) Gradle dependencies to add (currently works only with sdl2_gradle
 # bootstrap)
 #android.gradle_dependencies =
+
+# (list) add java compile options
+# this can for example be necessary when importing certain java libraries using the 'android.gradle_dependencies' option
+# see https://developer.android.com/studio/write/java8-support for further information
+# android.add_compile_options = "sourceCompatibility = 1.8", "targetCompatibility = 1.8"
+
+# (list) Gradle repositories to add {can be necessary for some android.gradle_dependencies}
+# please enclose in double quotes 
+# e.g. android.gradle_repositories = "maven { url 'https://kotlin.bintray.com/ktor' }"
+#android.add_gradle_repositories =
+
+# (list) packaging options to add 
+# see https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.PackagingOptions.html
+# can be necessary to solve conflicts in gradle_dependencies
+# please enclose in double quotes 
+# e.g. android.add_packaging_options = "exclude 'META-INF/common.kotlin_module'", "exclude 'META-INF/*.kotlin_module'"
+#android.add_gradle_repositories =
 
 # (list) Java classes to add as activities to the manifest.
 #android.add_activites = com.example.ExampleActivity

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -892,7 +892,8 @@ class TargetAndroid(Target):
         super(TargetAndroid, self).cmd_run(*args)
 
         entrypoint = self.buildozer.config.getdefault(
-            'app', 'android.entrypoint', 'org.renpy.android.PythonActivity')
+            'app', 'android.entrypoint', 'org.kivy.android.PythonActivity')
+
         package = self._get_package()
 
         # push on the device
@@ -1010,6 +1011,29 @@ class TargetAndroid(Target):
             permission[-1] = permission[-1].upper()
             permission = '.'.join(permission)
             build_cmd += [("--permission", permission)]
+
+        # android.entrypoint
+        entrypoint = config.getdefault('app', 'android.entrypoint', 'org.kivy.android.PythonActivity')
+        build_cmd += [('--android-entrypoint', entrypoint)]
+
+        # android.apptheme
+        apptheme = config.getdefault('app', 'android.apptheme', '@android:style/Theme.NoTitleBar')
+        build_cmd += [('--android-apptheme', apptheme)]
+
+        # android.compile_options
+        compile_options = config.getlist('app', 'android.add_compile_options', [])
+        for option in compile_options:
+            build_cmd += [('--add-compile-option', option)]
+
+        # android.add_gradle_repositories
+        repos = config.getlist('app','android.add_gradle_repositories', [])
+        for repo in repos:
+            build_cmd += [('--add-gradle-repository', repo)]
+
+        # android packaging options
+        pkgoptions = config.getlist('app','android.add_packaging_options', [])
+        for pkgoption in pkgoptions:
+            build_cmd += [('--add-packaging-option', pkgoption)]
 
         # meta-data
         meta_datas = config.getlistvalues('app', 'android.meta_data', [])


### PR DESCRIPTION
# customizability options for p4a

This PR introduces a set of options which deal with integration of java/kotlin libraries

- android entrypoint: this option already existed in buildozer but was not implemented in p4a.
    this allows to specify a custom class inherited class from org.kivy.android.PythonActivity as entrypoint
- android apptheme: specifies a custom app-theme for the main activity, will be generated into the manifest
- add_compiler_options
- gradle-repository: with this option it is possible to specify additional repositories for the gradle build
- packaging-options: results in packagingOptions in the gradle script, can be necessary to resolve conflicts in java/kotlin packages

this PR also includes changes from #912

this PR also needs kivy/python-for-android#1869