### PR TITLE
Extend add_libs to arm64-v8a

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -177,6 +177,7 @@ fullscreen = 0
 # (list) Android additional libraries to copy into libs/armeabi
 #android.add_libs_armeabi = libs/android/*.so
 #android.add_libs_armeabi_v7a = libs/android-v7/*.so
+#android.add_libs_arm64_v8a = libs/android-v8/*.so
 #android.add_libs_x86 = libs/android-x86/*.so
 #android.add_libs_mips = libs/android-mips/*.so
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -877,10 +877,11 @@ class TargetAndroid(Target):
         version = self.buildozer.get_version()
 
         # add extra libs/armeabi files in dist/default/libs/armeabi
-        # (same for armeabi-v7a, x86, mips)
+        # (same for armeabi-v7a, arm64-v8a, x86, mips)
         for config_key, lib_dir in (
             ('android.add_libs_armeabi', 'armeabi'),
             ('android.add_libs_armeabi_v7a', 'armeabi-v7a'),
+            ('android.add_libs_arm64_v8a', 'arm64-v8a'),            
             ('android.add_libs_x86', 'x86'),
             ('android.add_libs_mips', 'mips')):
 


### PR DESCRIPTION
This PR extends the android.add_libs to arm64-v8a .