### PR TITLE
New feature: allow to use a p4a fork

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -158,9 +158,6 @@ fullscreen = 0
 # (list) Java classes to add as activities to the manifest.
 #android.add_activites = com.example.ExampleActivity
 
-# (str) python-for-android branch to use, defaults to master
-#p4a.branch = master
-
 # (str) OUYA Console category. Should be one of GAME or APP
 # If you leave this blank, OUYA support will not be enabled
 #android.ouya.category = GAME
@@ -207,6 +204,9 @@ android.arch = armeabi-v7a
 #
 # Python for android (p4a) specific
 #
+
+# (str) python-for-android branch to use, defaults to master
+#p4a.branch = master
 
 # (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
 #p4a.source_dir =

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -205,6 +205,9 @@ android.arch = armeabi-v7a
 # Python for android (p4a) specific
 #
 
+# (str) python-for-android fork to use, defaults to upstream (kivy)
+#p4a.fork = kivy
+
 # (str) python-for-android branch to use, defaults to master
 #p4a.branch = master
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -47,6 +47,7 @@ DEPRECATED_TOKENS = (('app', 'android.sdk'), )
 # does.
 DEFAULT_SDK_TAG = '4333796'
 
+
 class TargetAndroid(Target):
     targetname = 'android'
     p4a_directory = "python-for-android"

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -50,6 +50,7 @@ DEFAULT_SDK_TAG = '4333796'
 class TargetAndroid(Target):
     targetname = 'android'
     p4a_directory = "python-for-android"
+    p4a_fork = 'kivy'
     p4a_branch = 'master'
     p4a_apk_cmd = "apk --debug --bootstrap="
     extra_p4a_args = ''
@@ -614,8 +615,12 @@ class TargetAndroid(Target):
 
     def _install_p4a(self):
         cmd = self.buildozer.cmd
-        source = self.buildozer.config.getdefault('app', 'p4a.branch',
-                                                  self.p4a_branch)
+        p4a_fork = self.buildozer.config.getdefault(
+            'app', 'p4a.fork', self.p4a_fork
+        )
+        p4a_branch = self.buildozer.config.getdefault(
+            'app', 'p4a.branch', self.p4a_branch
+        )
         self.pa_dir = pa_dir = join(self.buildozer.platform_dir,
                                     self.p4a_directory)
         system_p4a_dir = self.buildozer.config.getdefault('app',
@@ -630,20 +635,27 @@ class TargetAndroid(Target):
         else:
             if not self.buildozer.file_exists(pa_dir):
                 cmd(
-                    ('git clone -b {} --single-branch '
-                     'https://github.com/kivy/python-for-android.git '
-                     '{}').format(source, self.p4a_directory),
-                    cwd=self.buildozer.platform_dir)
+                    (
+                        'git clone -b {p4a_branch} --single-branch '
+                        'https://github.com/{p4a_fork}/python-for-android.git '
+                        '{p4a_dir}'
+                    ).format(
+                        p4a_branch=p4a_branch,
+                        p4a_fork=p4a_fork,
+                        p4a_dir=self.p4a_directory,
+                    ),
+                    cwd=self.buildozer.platform_dir,
+                )
             elif self.platform_update:
                 cmd('git clean -dxf', cwd=pa_dir)
                 current_branch = cmd('git rev-parse --abbrev-ref HEAD',
                                      get_stdout=True, cwd=pa_dir)[0].strip()
-                if current_branch == source:
+                if current_branch == p4a_branch:
                     cmd('git pull', cwd=pa_dir)
                 else:
-                    cmd('git fetch --tags origin {0}:{0}'.format(source),
+                    cmd('git fetch --tags origin {0}:{0}'.format(p4a_branch),
                         cwd=pa_dir)
-                    cmd('git checkout {}'.format(source), cwd=pa_dir)
+                    cmd('git checkout {}'.format(p4a_branch), cwd=pa_dir)
 
         # also install dependencies (currently, only setup.py knows about it)
         # let's extract them.


### PR DESCRIPTION
This PR adds the ability to use any p4a fork. So combined with buildozer.spec file key `p4a.branch` it will allows us to test any pull requests of `kivy/python-for-android` using buildozer. Also, an user could use his own fork/branch of p4a editing two keys from his buildozer.spec file: `p4a.fork` and `p4a.branch` to make use of his own fork/branch of p4a.

So...in this PR we do:
  - add a new key to buildozer.spec file: `p4a.fork`
  - check on each build that fork/branch has not been changed, and if so, remove the old p4a installation (which will trigger a new p4a's installation)
  - move key `p4a.branch` to proper section (python-for-android)...of course this is not mandatory, it's only to be neatest and to make easier to find the key
  - fix a pep8 error (two blank lines before class)

**Note:** The p4a fork it's supposed to have the same name than the the repository from kivy's organization (python-for-android), if that is not the case, don't expect this to work!!!