### PR TITLE
spec file: cast paths in source.exclude_dirs to lowercase

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -781,7 +781,7 @@ class Buildozer(object):
                 for exclude_dir in exclude_dirs:
                     if exclude_dir[-1] != '/':
                         exclude_dir += '/'
-                    if filtered_root.startswith(exclude_dir):
+                    if filtered_root.startswith(exclude_dir.lower()):
                         is_excluded = True
                         break
 


### PR DESCRIPTION
The paths tested against `source.exclude_dirs` (set in buildozer.spec) are cast to lowercase but the paths in source.exclude_dirs are left as-is:
https://github.com/kivy/buildozer/blob/182d13f1027d4c16e04e1096c94ed3e488226330/buildozer/__init__.py#L775
https://github.com/kivy/buildozer/blob/182d13f1027d4c16e04e1096c94ed3e488226330/buildozer/__init__.py#L784

This could result in confusion if the user lists non-lowercase paths in source.exclude_dirs as they would never match anything.