### PR TITLE
Code improvements around NDK download

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -26,10 +26,10 @@ from fnmatch import fnmatch
 
 from pprint import pformat
 
-try:
+try:  # Python 3
     from urllib.request import FancyURLopener
     from configparser import SafeConfigParser
-except ImportError:
+except ImportError:  # Python 2
     from urllib import FancyURLopener
     from ConfigParser import SafeConfigParser
 try:
@@ -151,22 +151,6 @@ class Buildozer(object):
         self.target = None
         if target:
             self.set_target(target)
-
-    @property
-    def user_build_dir(self):
-        '''The user-provided build dir.'''
-        # Check for a user-provided build dir
-        # Check the (deprecated) builddir token, for backwards compatibility
-        build_dir = self.config.getdefault('buildozer', 'builddir', None)
-        if build_dir:
-            # for backwards compatibility, append .buildozer to builddir
-            build_dir = join(build_dir, '.buildozer')
-        build_dir = self.config.getdefault('buildozer', 'build_dir', build_dir)
-
-        if build_dir is not None:
-            build_dir = realpath(join(self.root_dir, build_dir))
-
-        return build_dir
 
     def set_target(self, target):
         '''Set the target to use (one of buildozer.targets, such as "android")
@@ -888,6 +872,22 @@ class Buildozer(object):
         return realpath(dirname(self.specfilename))
 
     @property
+    def user_build_dir(self):
+        '''The user-provided build dir, if any.'''
+        # Check for a user-provided build dir
+        # Check the (deprecated) builddir token, for backwards compatibility
+        build_dir = self.config.getdefault('buildozer', 'builddir', None)
+        if build_dir:
+            # for backwards compatibility, append .buildozer to builddir
+            build_dir = join(build_dir, '.buildozer')
+        build_dir = self.config.getdefault('buildozer', 'build_dir', build_dir)
+
+        if build_dir is not None:
+            build_dir = realpath(join(self.root_dir, build_dir))
+
+        return build_dir
+
+    @property
     def buildozer_dir(self):
         '''The directory in which to run the app build.'''
         if self.user_build_dir is not None:
@@ -1125,13 +1125,13 @@ class Buildozer(object):
         '''
         if self.user_build_dir is not None:
             self.error(
-                ('Build dir is specified as {}. `appclean` will not attempt to delete files '
-                 'in a user-specified build directory.').format(self.user_build_dir))
+                ('Failed: build_dir is specified as {} in the buildozer config. `appclean` will '
+                 'not attempt to delete files in a user-specified build directory.').format(self.user_build_dir))
         elif exists(self.buildozer_dir):
             self.info('Deleting {}'.format(self.buildozer_dir))
             rmtree(self.buildozer_dir)
         else:
-            self.error('{} already deleted, skipping.'.format(app_build_dir))
+            self.error('{} already deleted, skipping.'.format(self.buildozer_dir))
 
     def cmd_help(self, *args):
         '''Show the Buildozer help.

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -873,11 +873,11 @@ class Buildozer(object):
 
     @property
     def user_build_dir(self):
-        '''The user-provided build dir, if any.'''
+        """The user-provided build dir, if any."""
         # Check for a user-provided build dir
         # Check the (deprecated) builddir token, for backwards compatibility
         build_dir = self.config.getdefault('buildozer', 'builddir', None)
-        if build_dir:
+        if build_dir is not None:
             # for backwards compatibility, append .buildozer to builddir
             build_dir = join(build_dir, '.buildozer')
         build_dir = self.config.getdefault('buildozer', 'build_dir', build_dir)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -798,8 +798,8 @@ class TargetAndroid(Target):
         return True
 
     def get_dist_dir(self, dist_name, arch):
-        """
-        Find the dist dir with the given name and target arch.
+        """Find the dist dir with the given name and target arch, if one
+        already exists, otherwise return a new dist_dir name.
         """
         expected_dist_name = generate_dist_folder_name(dist_name, arch_names=[arch])
 

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -159,7 +159,7 @@ class TargetOSX(Target):
         self.buildozer.info('{}.dmg created'.format(package_name))
         self.buildozer.info('moving {}.dmg to bin.'.format(package_name))
         binpath = join(
-            self.buildozer.build_dir or
+            self.buildozer.user_build_dir or
             dirname(abspath(self.buildozer.specfilename)), 'bin')
         check_output(
             ('cp', '-a', package_name+'.dmg', binpath),
@@ -264,4 +264,3 @@ class TargetOSX(Target):
 
 def get_target(buildozer):
     return TargetOSX(buildozer)
-

--- a/tests/scripts/test_client.py
+++ b/tests/scripts/test_client.py
@@ -1,9 +1,12 @@
 import sys
-import mock
 import unittest
 from buildozer import BuildozerCommandException
 from buildozer.scripts import client
 
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 class TestClient(unittest.TestCase):
 

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -1,15 +1,19 @@
 import re
 import os
 import codecs
-import mock
 import unittest
 import buildozer as buildozer_module
 from buildozer import Buildozer, IS_PY3
 from six import StringIO
 import tempfile
 
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
+
 from buildozer.targets.android import (
-    TargetAndroid, ANDROID_NDK_VERSION, MSG_P4A_RECOMMENDED_NDK_ERROR
+    TargetAndroid, DEFAULT_ANDROID_NDK_VERSION, MSG_P4A_RECOMMENDED_NDK_ERROR
 )
 
 
@@ -203,25 +207,25 @@ class TestBuildozer(unittest.TestCase):
                 mock.call(command_output)
             ]
 
-    def test_p4a_best_ndk_version_default_value(self):
+    def test_p4a_recommended_ndk_version_default_value(self):
         self.set_specfile_log_level(self.specfile.name, 1)
         buildozer = Buildozer(self.specfile.name, 'android')
-        assert buildozer.target.p4a_best_ndk_version is None
+        assert buildozer.target.p4a_recommended_ndk_version is None
 
-    def test_p4a_best_android_ndk_error(self):
+    def test_p4a_recommended_android_ndk_error(self):
         self.set_specfile_log_level(self.specfile.name, 1)
         buildozer = Buildozer(self.specfile.name, 'android')
 
         with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
-            ndk_version = buildozer.target.p4a_best_android_ndk
+            ndk_version = buildozer.target.p4a_recommended_android_ndk
         assert MSG_P4A_RECOMMENDED_NDK_ERROR in mock_stdout.getvalue()
         # and we should get the default android's ndk version of buildozer
-        assert ndk_version == ANDROID_NDK_VERSION
+        assert ndk_version == DEFAULT_ANDROID_NDK_VERSION
 
     @mock.patch('buildozer.targets.android.os.path.isfile')
     @mock.patch('buildozer.targets.android.os.path.exists')
     @mock.patch('buildozer.targets.android.open')
-    def test_p4a_best_android_ndk_found(
+    def test_p4a_recommended_android_ndk_found(
             self, mock_open, mock_exists, mock_isfile
     ):
         self.set_specfile_log_level(self.specfile.name, 1)
@@ -234,16 +238,16 @@ class TestBuildozer(unittest.TestCase):
                     expected_ndk=expected_ndk)
             ).return_value
         ]
-        ndk_version = buildozer.target.p4a_best_android_ndk
-        pa_dir = os.path.join(
-            buildozer.platform_dir, buildozer.target.p4a_directory)
+        ndk_version = buildozer.target.p4a_recommended_android_ndk
+        p4a_dir = os.path.join(
+            buildozer.platform_dir, buildozer.target.p4a_directory_name)
         mock_open.assert_called_once_with(
-            os.path.join(pa_dir, "pythonforandroid", "recommendations.py"), 'r'
+            os.path.join(p4a_dir, "pythonforandroid", "recommendations.py"), 'r'
         )
         assert ndk_version == expected_ndk
 
         # now test that we only read one time p4a file, so we call again to
-        # `p4a_best_android_ndk` and we should still have one call to `open`
+        # `p4a_recommended_android_ndk` and we should still have one call to `open`
         # file, the performed above
-        ndk_version = buildozer.target.p4a_best_android_ndk
+        ndk_version = buildozer.target.p4a_recommended_android_ndk
         mock_open.assert_called_once()

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -7,10 +7,13 @@ from buildozer import Buildozer, IS_PY3
 from six import StringIO
 import tempfile
 
-try:
-    from unittest import mock  # Python 3
-except ImportError:
-    import mock  # Python 2
+# try:
+#     from unittest import mock  # Python 3
+#     print('Got mock from unittest')
+# except ImportError:
+#     import mock  # Python 2
+#     print('Got mock from pip')
+import mock
 
 from buildozer.targets.android import (
     TargetAndroid, DEFAULT_ANDROID_NDK_VERSION, MSG_P4A_RECOMMENDED_NDK_ERROR
@@ -244,6 +247,10 @@ class TestBuildozer(unittest.TestCase):
         mock_open.assert_called_once_with(
             os.path.join(p4a_dir, "pythonforandroid", "recommendations.py"), 'r'
         )
+        print('Found "{}" vs expected "{}"'.format(ndk_version, expected_ndk))
+        print('Values are equal: {}'.format(ndk_version == expected_ndk))
+        print('Types {} {}'.format(type(ndk_version), type(expected_ndk)))
+        print('Lengths {} {}'.format(len(ndk_version), len(expected_ndk)))
         assert ndk_version == expected_ndk
 
         # now test that we only read one time p4a file, so we call again to

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -224,7 +224,7 @@ class TestBuildozer(unittest.TestCase):
 
     @mock.patch('buildozer.targets.android.os.path.isfile')
     @mock.patch('buildozer.targets.android.os.path.exists')
-    @mock.patch('buildozer.targets.android.open')
+    @mock.patch('buildozer.targets.android.open', create=True)
     def test_p4a_recommended_android_ndk_found(
             self, mock_open, mock_exists, mock_isfile
     ):

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -7,12 +7,6 @@ from buildozer import Buildozer, IS_PY3
 from six import StringIO
 import tempfile
 
-# try:
-#     from unittest import mock  # Python 3
-#     print('Got mock from unittest')
-# except ImportError:
-#     import mock  # Python 2
-#     print('Got mock from pip')
 import mock
 
 from buildozer.targets.android import (
@@ -247,10 +241,6 @@ class TestBuildozer(unittest.TestCase):
         mock_open.assert_called_once_with(
             os.path.join(p4a_dir, "pythonforandroid", "recommendations.py"), 'r'
         )
-        print('Found "{}" vs expected "{}"'.format(ndk_version, expected_ndk))
-        print('Values are equal: {}'.format(ndk_version == expected_ndk))
-        print('Types {} {}'.format(type(ndk_version), type(expected_ndk)))
-        print('Lengths {} {}'.format(len(ndk_version), len(expected_ndk)))
         assert ndk_version == expected_ndk
 
         # now test that we only read one time p4a file, so we call again to


### PR DESCRIPTION
Made a few improvements while checking NDK version downloads were working correctly.

I'm pretty satisfied that everything is good, thanks @opacam for doing the real work here.

In particular, the scenarios that need covering are:
- New install: buildozer downloads p4a latest release then a matching NDK.
- P4a already downloaded: buildozer checks the p4a recommendations and fetches a matching NDK.
- NDK already downloaded: buildozer downloads p4a latest release, then fetches a matching NDK if necessary.

I was worried there might be some issues with how buildozer stores the NDKs, but it all seems basically good.

Also added a new command `buildozer appclean` that deletes the build directory (i.e. app_dir/.buildozer), because this is much nicer than telling users to delete it themselves.