### PR TITLE
Rename final apk with arch in the name

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1127,8 +1127,10 @@ class TargetAndroid(Target):
             apk = u'{packagename}-{mode}.apk'.format(
                 packagename=packagename, mode=mode)
             apk_dir = join(dist_dir, "build", "outputs", "apk", mode_sign)
-            apk_dest = u'{packagename}-{version}-{mode}.apk'.format(
-                packagename=packagename, mode=mode, version=version)
+
+            apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
+                packagename=packagename, mode=mode, version=version,
+                arch=self._arch)
 
         else:
             # on ant, the apk use the title, and have version
@@ -1143,6 +1145,11 @@ class TargetAndroid(Target):
                 mode=mode)
             apk_dir = join(dist_dir, "bin")
             apk_dest = apk
+
+            packagename = config.get('app', 'package.name')
+            apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
+                packagename=packagename, mode=mode, version=version,
+                arch=self._arch)
 
         # copy to our place
         copyfile(join(apk_dir, apk), join(self.buildozer.bin_dir, apk_dest))

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1127,11 +1127,6 @@ class TargetAndroid(Target):
             apk = u'{packagename}-{mode}.apk'.format(
                 packagename=packagename, mode=mode)
             apk_dir = join(dist_dir, "build", "outputs", "apk", mode_sign)
-
-            apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
-                packagename=packagename, mode=mode, version=version,
-                arch=self._arch)
-
         else:
             # on ant, the apk use the title, and have version
             bl = u'\'" ,'
@@ -1144,12 +1139,11 @@ class TargetAndroid(Target):
                 version=version,
                 mode=mode)
             apk_dir = join(dist_dir, "bin")
-            apk_dest = apk
-
             packagename = config.get('app', 'package.name')
-            apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
-                packagename=packagename, mode=mode, version=version,
-                arch=self._arch)
+
+        apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
+            packagename=packagename, mode=mode, version=version,
+            arch=self._arch)
 
         # copy to our place
         copyfile(join(apk_dir, apk), join(self.buildozer.bin_dir, apk_dest))

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1120,10 +1120,10 @@ class TargetAndroid(Target):
         gradle_files = ["build.gradle", "gradle", "gradlew"]
         is_gradle_build = build_tools_version >= "25.0" and any(
             (exists(join(dist_dir, x)) for x in gradle_files))
+        packagename = config.get('app', 'package.name')
 
         if is_gradle_build:
             # on gradle build, the apk use the package name, and have no version
-            packagename = config.get('app', 'package.name')
             apk = u'{packagename}-{mode}.apk'.format(
                 packagename=packagename, mode=mode)
             apk_dir = join(dist_dir, "build", "outputs", "apk", mode_sign)
@@ -1139,7 +1139,6 @@ class TargetAndroid(Target):
                 version=version,
                 mode=mode)
             apk_dir = join(dist_dir, "bin")
-            packagename = config.get('app', 'package.name')
 
         apk_dest = u'{packagename}-{version}-{arch}-{mode}.apk'.format(
             packagename=packagename, mode=mode, version=version,


### PR DESCRIPTION
If i do 2 build with the same buildozer spec, but 2 profiles with different arch (or 2 buildozer spec), i don't want the final apk to be overwritten. So now the final apk name contains the arch:

For example:
- `connectage-0.4.0.23-arm64-v8a-release.apk`
- `connectage-0.4.0.23-armeabi-v7a-release.apk`