### PR TITLE
Add libs only for current arch

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -970,6 +970,8 @@ class TargetAndroid(Target):
             patterns = config.getlist('app', config_key, [])
             if not patterns:
                 continue
+            if self._arch != lib_dir:
+                continue
 
             self.buildozer.debug('Search and copy libs for {}'.format(lib_dir))
             for fn in self.buildozer.file_matches(patterns):


### PR DESCRIPTION
When multiple `android.add_libs_*` are present, buildozer is trying (and failing) to copy libs also for non-current arch.

This PR goal is to leave the `buildozer.spec` file unchanged when targeting multiple archs except for the `android.arch` option. 