### PR TITLE
android gradle build: fix apk name

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1181,9 +1181,9 @@ class TargetAndroid(Target):
 
         if is_gradle_build:
             # on gradle build, the apk use the package name, and have no version
-            packagename = basename(dist_dir)  # gradle specifically uses the folder name
+            packagename_src = basename(dist_dir)  # gradle specifically uses the folder name
             apk = u'{packagename}-{mode}.apk'.format(
-                packagename=packagename, mode=mode)
+                packagename=packagename_src, mode=mode)
             apk_dir = join(dist_dir, "build", "outputs", "apk", mode_sign)
         else:
             # on ant, the apk use the title, and have version


### PR DESCRIPTION
When I use p4a (https://github.com/kivy/python-for-android/commit/b1f6064d9644a532f52728218e42da37d54f502c) and buildozer (e5cc1855da9757c0f99449bddbc2aebdce450e58) to build an android apk with gradle, the apk gets named as e.g.:
`Electrum__arm64-v8a-4.0.0.0-arm64-v8a-debug.apk`
Note that the arch is duplicated...

See these commits, which collectively ultimately lead to the broken naming:
https://github.com/kivy/buildozer/commit/c92b3ef9253e60f8a622844a045f4689b9296d1e
https://github.com/kivy/buildozer/commit/d483847bb57fb46d4d5b1e4b5ca8bca4a41c08a9
https://github.com/kivy/buildozer/commit/9fcf28ba447d0d4930f98d515daad2b290d20aa7

