### PR TITLE
Updates default buildozer.spec NDK from 17c to 19b

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -97,7 +97,7 @@ fullscreen = 0
 #android.sdk = 20
 
 # (str) Android NDK version to use
-#android.ndk = 17c
+#android.ndk = 19b
 
 # (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
 #android.ndk_api = 21


### PR DESCRIPTION
Note that this is only the template spec file and
`DEFAULT_ANDROID_NDK_VERSION` fallback is left untouched.