### PR TITLE
[Python2.7] #1052 ImportError: cannot import name 'main'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Build with:
 # docker build --tag=kivy/buildozer .
-# 
+#
 # In order to give the container access to your current working directory
 # it must be mounted using the --volume option.
 # Run with (e.g. `buildozer --version`):
@@ -57,6 +57,8 @@ RUN apt install -qq --yes --no-install-recommends \
     patch \
     pkg-config \
     python2.7 \
+    python-pip \
+    python-setuptools \
     python3-pip \
     python3-setuptools \
     sudo \
@@ -76,5 +78,7 @@ COPY --chown=user:user . ${SRC_DIR}
 
 # installs buildozer and dependencies
 RUN pip3 install --user Cython==0.28.6 ${SRC_DIR}
+
+RUN python2.7 -m pip install -U pip virtualenv
 
 ENTRYPOINT ["buildozer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,6 @@ COPY --chown=user:user . ${SRC_DIR}
 # installs buildozer and dependencies
 RUN pip3 install --user Cython==0.28.6 ${SRC_DIR}
 
-RUN python2.7 -m pip install -U pip virtualenv
+RUN pip install -U pip virtualenv
 
 ENTRYPOINT ["buildozer"]


### PR DESCRIPTION
Original Issue is: [ImportError: cannot import name 'main' #1052](https://github.com/kivy/buildozer/issues/1052)

This is the fix for the same bug but in python 2.7 [(comment here)](https://github.com/kivy/buildozer/issues/1052#issuecomment-611048262)
