### PR TITLE
Setup coverage testing, closes #1058

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Requirements
       run: |
-        pip install --timeout=120 -U setuptools tox>=2.0
+        pip install -U coveralls setuptools tox>=2.0
         tox
     - name: Build
       run: |
@@ -33,3 +33,7 @@ jobs:
     - name: Test
       run: |
         docker run buildozer --version
+    - name: coveralls
+      run: coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Buildozer
 =========
 
 [![Build](https://github.com/kivy/buildozer/workflows/Continuous%20Integration/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3A%22Continuous+Integration%22)
+[![Coverage Status](https://coveralls.io/repos/github/kivy/buildozer/badge.svg)](https://coveralls.io/github/kivy/buildozer)
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,14 @@ envlist = pep8,py27,py3
 deps =
     mock
     pytest
+    py3: coverage
 commands = pytest tests/
+
+[testenv:py3]
+# for py3 env we will get code coverage
+commands =
+    coverage run --branch --source=buildozer -m pytest {posargs:tests/}
+    coverage report -m
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Also enables report to coveralls.io via GitHub Action.
Note the `COVERALLS_REPO_TOKEN` was setup via:
https://github.com/kivy/buildozer/settings/secrets
And is accessible for repos admin via:
https://coveralls.io/github/kivy/buildozer

This is a follow up for https://github.com/kivy/buildozer/pull/1059 branching from upstream to have access to the secrets