### PR TITLE
Fixes coveralls.io on pull requests

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -26,15 +26,16 @@ jobs:
     - name: Requirements
       run: |
         pip install -U coveralls setuptools tox>=2.0
-        tox
-    - name: Build
+    - name: Tox
+      run: tox
+    - name: Docker build
       run: |
         docker build --tag=buildozer .
-    - name: Test
+    - name: Docker run
       run: |
         docker run buildozer --version
-    - name: coveralls
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      run: coveralls
+    - name: Coveralls
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NAME: github
+      run: coveralls


### PR DESCRIPTION
~~This is some tests and not supposed to be merged until completed~~ Completed!

Coveralls.io now runs on pull requests as well.
The report is automatically uploaded on coveralls.io however it needs to be accessed by copying the report URL to review it.
Next up would be to have it commenting on the pull request to see on first sight if it increased or decreased.
Also made a couple of adjustment to the workflow file to clarify between requirements building, Docker build/run and actual testing.