### PR TITLE
Linting organisation and fixes

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -940,7 +940,6 @@ class Buildozer(object):
             return package_name
         return '{}.{}'.format(package_domain, package_name)
 
-
     #
     # command line invocation
     #
@@ -1197,8 +1196,6 @@ class Buildozer(object):
                 print('merged ({}, {}) into {} (profile is {})'.format(name,
                         value, section_base, profile))
                 self.config.set(section_base, name, value)
-
-
 
     def _get_config_list_values(self, *args, **kwargs):
         kwargs['with_values'] = True

--- a/buildozer/jsonstore.py
+++ b/buildozer/jsonstore.py
@@ -53,4 +53,3 @@ class JsonStore(object):
         else:
             with io.open(self.filename, 'w', encoding='utf-8') as fd:
                 fd.write(unicode(dumps(self.data, ensure_ascii=False)))
-

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -328,13 +328,12 @@ class TargetAndroid(Target):
         import _winreg
         with _winreg.OpenKey(
                 _winreg.HKEY_LOCAL_MACHINE,
-                r"SOFTWARE\JavaSoft\Java Development Kit") as jdk:  #@UndefinedVariable
+                r"SOFTWARE\JavaSoft\Java Development Kit") as jdk:  # @UndefinedVariable
             current_version, _type = _winreg.QueryValueEx(
-                jdk, "CurrentVersion")  #@UndefinedVariable
-            with _winreg.OpenKey(jdk,
-                                 current_version) as cv:  #@UndefinedVariable
+                jdk, "CurrentVersion")  # @UndefinedVariable
+            with _winreg.OpenKey(jdk, current_version) as cv:  # @UndefinedVariable
                 java_home, _type = _winreg.QueryValueEx(
-                    cv, "JavaHome")  #@UndefinedVariable
+                    cv, "JavaHome")  # @UndefinedVariable
             self.buildozer.environ['JAVA_HOME'] = java_home
 
     def _locate_java(self, s):
@@ -517,7 +516,6 @@ class TargetAndroid(Target):
         revision = line.split('=')[1].strip()
 
         return revision
-
 
     def _android_update_sdk(self, *sdkmanager_commands):
         """Update the tools and package-tools if possible"""
@@ -922,7 +920,7 @@ class TargetAndroid(Target):
         entrypoint = self.buildozer.config.getdefault(
             'app', 'android.entrypoint')
         if not entrypoint:
-            self.buildozer.config.set('app', 'android.entrypoint',  'org.kivy.android.PythonActivity')
+            self.buildozer.config.set('app', 'android.entrypoint', 'org.kivy.android.PythonActivity')
 
         super(TargetAndroid, self).cmd_run(*args)
 
@@ -995,11 +993,11 @@ class TargetAndroid(Target):
         # add extra libs/armeabi files in dist/default/libs/armeabi
         # (same for armeabi-v7a, arm64-v8a, x86, mips)
         for config_key, lib_dir in (
-            ('android.add_libs_armeabi', 'armeabi'),
-            ('android.add_libs_armeabi_v7a', 'armeabi-v7a'),
-            ('android.add_libs_arm64_v8a', 'arm64-v8a'),
-            ('android.add_libs_x86', 'x86'),
-            ('android.add_libs_mips', 'mips')):
+                ('android.add_libs_armeabi', 'armeabi'),
+                ('android.add_libs_armeabi_v7a', 'armeabi-v7a'),
+                ('android.add_libs_arm64_v8a', 'arm64-v8a'),
+                ('android.add_libs_x86', 'x86'),
+                ('android.add_libs_mips', 'mips')):
 
             patterns = config.getlist('app', config_key, [])
             if not patterns:
@@ -1289,10 +1287,10 @@ class TargetAndroid(Target):
         serial = environ.get('ANDROID_SERIAL')
         if serial:
             return serial.split(',')
-        l = self.buildozer.cmd('{} devices'.format(self.adb_cmd),
+        lines = self.buildozer.cmd('{} devices'.format(self.adb_cmd),
                                get_stdout=True)[0].splitlines()
         serials = []
-        for serial in l:
+        for serial in lines:
             if not serial:
                 continue
             if serial.startswith('*') or serial.startswith('List '):

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -35,7 +35,7 @@ class TargetOSX(Target):
         if exists(
             join(self.buildozer.platform_dir, 'kivy-sdk-packager-master')):
             self.buildozer.info(
-                    'kivy-sdk-packager found at '\
+                    'kivy-sdk-packager found at '
                 '{}'.format(self.buildozer.platform_dir))
             return
 
@@ -62,7 +62,7 @@ class TargetOSX(Target):
                 self.buildozer.info('Downloading kivy...')
                 status_code = check_output(
                     ('curl', '-L', '--write-out', '%{http_code}', '-o', 'Kivy{}.dmg'.format(py_branch),
-                    'http://kivy.org/downloads/{}/Kivy-{}-osx-python{}.dmg'\
+                    'http://kivy.org/downloads/{}/Kivy-{}-osx-python{}.dmg'
                     .format(current_kivy_vers, current_kivy_vers, py_branch)),
                     cwd=cwd)
 
@@ -162,7 +162,7 @@ class TargetOSX(Target):
             self.buildozer.user_build_dir or
             dirname(abspath(self.buildozer.specfilename)), 'bin')
         check_output(
-            ('cp', '-a', package_name+'.dmg', binpath),
+            ('cp', '-a', package_name + '.dmg', binpath),
             cwd=cwd)
         self.buildozer.info('All Done!')
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,27 +27,18 @@ ignore =
     E126, # continuation line over-indented for hanging indent
     E127, # continuation line over-indented for visual indent
     E128, # continuation line under-indented for visual indent
-    E129, # visually indented line with same indent as next logical line
     E131, # continuation line unaligned for hanging indent
-    E226, # missing whitespace around arithmetic operator
     E231, # missing whitespace after ','
-    E241, # multiple spaces after ','
-    E262, # inline comment should start with '# '
     E265, # block comment should start with '# '
-    E301, # expected 1 blank line, found 0
     E302, # expected 2 blank lines, found 1
-    E303, # too many blank lines
     E305, # expected 2 blank lines after class or function definition, found 1
     E402, # module level import not at top of file
     E501, # line too long
-    E502, # the backslash is redundant between brackets
     E722, # do not use bare 'except'
     E731, # do not assign a lambda expression, use a def
-    E741, # ambiguous variable name
     F401, # imported but unused
     F821, # undefined name
     F841, # local variable is assigned to but never used
-    W391, # blank line at end of file
     W503, # line break before binary operator
     W504, # line break after binary operator
     W605  # invalid escape sequence

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,38 @@ commands =
 
 [testenv:pep8]
 deps = flake8
-commands = flake8 buildozer/
+commands = flake8 buildozer/ tests/
 
 [flake8]
 ignore =
-    E121, E122, E123, E125, E126, E127, E128, E129, E131, E226, E231, E241,
-    E262, E265, E301, E302, E303, E305, E402, E501, E502, E722, E731, E741,
-    F401, F821, F841, W391, W504, W605
+    E121, # continuation line under-indented for hanging indent
+    E122, # continuation line missing indentation or outdented
+    E123, # closing bracket does not match indentation of opening bracket's line
+    E125, # continuation line with same indent as next logical line
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E129, # visually indented line with same indent as next logical line
+    E131, # continuation line unaligned for hanging indent
+    E226, # missing whitespace around arithmetic operator
+    E231, # missing whitespace after ','
+    E241, # multiple spaces after ','
+    E262, # inline comment should start with '# '
+    E265, # block comment should start with '# '
+    E301, # expected 1 blank line, found 0
+    E302, # expected 2 blank lines, found 1
+    E303, # too many blank lines
+    E305, # expected 2 blank lines after class or function definition, found 1
+    E402, # module level import not at top of file
+    E501, # line too long
+    E502, # the backslash is redundant between brackets
+    E722, # do not use bare 'except'
+    E731, # do not assign a lambda expression, use a def
+    E741, # ambiguous variable name
+    F401, # imported but unused
+    F821, # undefined name
+    F841, # local variable is assigned to but never used
+    W391, # blank line at end of file
+    W503, # line break before binary operator
+    W504, # line break after binary operator
+    W605  # invalid escape sequence


### PR DESCRIPTION
* Organises linter errors and check tests/ directory
* PEP8 fixes
    - E129 visually indented line with same indent as next logical line
    - E226 missing whitespace around arithmetic operator
    - E241 multiple spaces after ','
    - E262 inline comment should start with '# '
    - E301 expected 1 blank line, found 0
    - E303 too many blank lines
    - E502 the backslash is redundant between bracket
    - E741 ambiguous variable name
    - W391 blank line at end of file