### PR TITLE
WIP: Coveralls to report via webhook

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -28,14 +28,27 @@ jobs:
         pip install -U coveralls setuptools tox>=2.0
     - name: Tox
       run: tox
-    - name: Docker build
-      run: |
-        docker build --tag=buildozer .
-    - name: Docker run
-      run: |
-        docker run buildozer --version
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github
       run: coveralls
+
+  Docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Docker build
+      run: docker build --tag=kivy/buildozer .
+    - name: Docker run
+      run: docker run kivy/buildozer --version
+
+  coveralls_finish:
+    needs: Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        parallel-finished: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This enables coveralls webhook, so the actual coveralls results appears on the pull request itself.
Also created a dedicated job for Docker testing so it can run in parallel with the other tests.
Prior this change the CI was running in 3 minutes, it now runs in 2.