### PR TITLE
Checks SDK, NDK and p4a get downloaded on first run

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -58,6 +58,10 @@ jobs:
         pip install Cython==0.28.6
     - run: buildozer --help
     - run: buildozer init
+    - name: SDK, NDK and p4a download
+      run: |
+        sed "s/# android.accept_sdk_license = False/android.accept_sdk_license = True/" -i buildozer.spec
+        buildozer android p4a -- --help
 
   Python2:
     runs-on: ubuntu-latest


### PR DESCRIPTION
calling the `p4a` command would trigger all the downloads so we can verify it works as expected. Note this phase adds a 1.5 minute overhead