### PR TITLE
:bug: Fixes missing libssl-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,11 @@ RUN apt install -qq --yes --no-install-recommends \
     git \
     libffi-dev \
     libltdl-dev \
+    libssl-dev \
     libtool \
     openjdk-8-jdk \
     patch \
     pkg-config \
-    python2.7 \
     python3-pip \
     python3-setuptools \
     sudo \


### PR DESCRIPTION
This is required for the minimal build, closes #1096
Also drops Python 2 dependency.
Integration test will come after #1093 is merged