### PR TITLE
:green_heart: Automatically publish to PyPI upon tagging

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,25 @@
+name: PyPI release
+on: [push]
+
+jobs:
+  pypi_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,9 @@ setup(
         'Development Status :: 4 - Beta', 'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
-        'Programming Language :: Python :: 3.7'
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
New `pypi-release.yml` workflow for deploying to PyPI.
The scoped token is already setup in:
https://github.com/kivy/buildozer/settings/secrets

Also fixes `setup.py` classifier. The error was:
HTTPError: 400 Client Error: Invalid value for classifiers.
Error: Classifier 'Programming Language :: Python :: 3.6Programming Language :: Python :: 3.7Programming Language :: Python :: 3.8'
is not a valid classifier. for url: https://upload.pypi.org/legacy/

Tested by changing the version to an existing one and testing the upload:
```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading buildozer-1.0-py3-none-any.whl
Uploading buildozer-1.0.tar.gz
HTTPError: 400 Client Error: File already exists.
See https://pypi.org/help/#file-name-reuse for url: https://upload.pypi.org/legacy/
```
https://github.com/AndreMiras/buildozer/runs/681413972