### PR TITLE
:whale: Fixes Docker apt cache missed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ ENV LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8"
 
 # system requirements to build most of the recipes
-RUN apt install -qq --yes --no-install-recommends \
+RUN apt update -qq > /dev/null && \
+    apt install -qq --yes --no-install-recommends \
     autoconf \
     automake \
     build-essential \


### PR DESCRIPTION
Applies "cache busting" to avoid apt cache miss:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
The error was:
```
After this operation, 905 MB of additional disk space will be used.
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/f/file/libmagic-mgc_5.32-2ubuntu0.3_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/f/file/libmagic1_5.32-2ubuntu0.3_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/f/file/file_5.32-2ubuntu0.3_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.15.0-96.97_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/cups/libcups2_2.2.7-1ubuntu2.7_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-common_2.4.45+dfsg-1ubuntu1.4_all.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-2.4-2_2.4.45+dfsg-1ubuntu1.4_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_11.1-1ubuntu7.5_amd64.deb 404 Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```