### PR TITLE
:wastebasket: Linter fixes and README.md update

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Try Python 2 install
       run: |
-        # we don't want to build to fail with the exit 1 so we catch with "||"
+        # we don't want the build to fail with the exit 1 so we catch with "||"
         python2 -m pip install -e . 2> error.log || echo Failing as expected
         cat error.log
         grep "Unsupported Python version" error.log

--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ project, and for iOS via the kivy-ios project. iOS and OSX are still under work.
 
 For Android, buildozer will automatically download and prepare the
 build dependencies. For more information, see
-[Android-SDK-NDK-Information](https://github.com/kivy/kivy/wiki/Android-SDK-NDK-Information). We
-recommend targeting Python 3 on Android, but you can target both
-Python 3 and Python 2 regardless of which version you use with
-buildozer on the desktop.
+[Android-SDK-NDK-Information](https://github.com/kivy/kivy/wiki/Android-SDK-NDK-Information).
+Note that only Python 3 is supported.
 
 Note that this tool has nothing to do with the eponymous online build service
 [buildozer.io](http://buildozer.io).

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -617,10 +617,6 @@ class Buildozer:
 
     def file_extract(self, archive, cwd=None):
         if archive.endswith('.tgz') or archive.endswith('.tar.gz'):
-            # XXX tarfile doesn't work for NDK-r8c :(
-            #tf = tarfile.open(archive, 'r:*')
-            #tf.extractall(path=cwd)
-            #tf.close()
             self.cmd('tar xzf {0}'.format(archive), cwd=cwd)
             return
 
@@ -631,8 +627,8 @@ class Buildozer:
 
         if archive.endswith('.bin'):
             # To process the bin files for linux and darwin systems
-            self.cmd('chmod a+x {0}'.format(archive),cwd=cwd)
-            self.cmd('./{0}'.format(archive),cwd=cwd)
+            self.cmd('chmod a+x {0}'.format(archive), cwd=cwd)
+            self.cmd('./{0}'.format(archive), cwd=cwd)
             return
 
         if archive.endswith('.zip'):
@@ -830,7 +826,6 @@ class Buildozer:
 
         main_py = join(self.app_dir, 'service', 'main.py')
         if not self.file_exists(main_py):
-            #self.error('Unable to patch main_py to add applibs directory.')
             return
 
         header = (b'import sys, os; '
@@ -847,7 +842,7 @@ class Buildozer:
         '''Return a "valid" name from a name with lot of invalid chars
         (allowed characters: a-z, A-Z, 0-9, -, _)
         '''
-        return re.sub('[^a-zA-Z0-9_\-]', '_', name)
+        return re.sub(r'[^a-zA-Z0-9_\-]', '_', name)
 
     @property
     def root_dir(self):
@@ -1248,6 +1243,7 @@ def set_config_from_envs(config):
     for section in config.sections():
         for token in config.options(section):
             set_config_token_from_env(section, token, config)
+
 
 def set_config_token_from_env(section, token, config):
     '''Given a config section and token, checks for an appropriate

--- a/buildozer/jsonstore.py
+++ b/buildozer/jsonstore.py
@@ -6,14 +6,13 @@ This was needed to correctly support db between Python 2 and 3.
 __all__ = ["JsonStore"]
 
 import io
-import sys
-from json import load, dump, dumps
+from json import load, dump
 from os.path import exists
+
 
 class JsonStore:
 
     def __init__(self, filename):
-        super().__init__()
         self.filename = filename
         self.data = {}
         if exists(filename):

--- a/buildozer/libs/_structures.py
+++ b/buildozer/libs/_structures.py
@@ -41,6 +41,7 @@ class Infinity:
     def __neg__(self):
         return NegativeInfinity
 
+
 Infinity = Infinity()
 
 
@@ -72,5 +73,6 @@ class NegativeInfinity:
 
     def __neg__(self):
         return Infinity
+
 
 NegativeInfinity = NegativeInfinity()

--- a/buildozer/libs/version.py
+++ b/buildozer/libs/version.py
@@ -162,6 +162,7 @@ def _legacy_cmpkey(version):
 
     return epoch, parts
 
+
 # Deliberately not anchored to the start and end of the string, to make it
 # easier for 3rd party code to reuse
 VERSION_PATTERN = r"""

--- a/buildozer/scripts/client.py
+++ b/buildozer/scripts/client.py
@@ -19,5 +19,6 @@ def main():
         Buildozer().error('%s' % error)
         sys.exit(1)
 
+
 if __name__ == '__main__':
     main()

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -27,7 +27,6 @@ except ImportError:
     from ConfigParser import SafeConfigParser
 try:
     import termios
-    import tty
     has_termios = True
 except ImportError:
     has_termios = False
@@ -131,7 +130,7 @@ class BuildozerRemote(Buildozer):
                 self.package_full_name)
         self.debug('Remote build directory: {}'.format(self.remote_build_dir))
         self._ssh_mkdir(self.remote_build_dir)
-        self._ssh_sync(__path__[0])
+        self._ssh_sync(__path__[0])  # noqa: F821 undefined name
 
     def _sync_application_sources(self):
         self.info('Synchronize application sources')
@@ -159,7 +158,7 @@ class BuildozerRemote(Buildozer):
             self.remote_build_dir,
             '--verbose' if self.log_level == 2 else '',
             ' '.join(args),
-            )
+        )
         self._ssh_command(cmd)
 
     def _ssh_mkdir(self, *args):
@@ -180,7 +179,7 @@ class BuildozerRemote(Buildozer):
         directory = realpath(directory)
         base_strip = directory.rfind('/')
         if mode == 'get':
-            local_dir = join(directory,'bin')
+            local_dir = join(directory, 'bin')
             remote_dir = join(self.remote_build_dir, 'bin')
             if not exists(local_dir):
                 makedirs(local_dir)
@@ -200,9 +199,6 @@ class BuildozerRemote(Buildozer):
 
     def _ssh_command(self, command):
         self.debug('Execute remote command {}'.format(command))
-        #shell = self._ssh_client.invoke_shell()
-        #shell.sendall(command)
-        #shell.sendall('\nexit\n')
         transport = self._ssh_client.get_transport()
         channel = transport.open_session()
         try:
@@ -220,8 +216,6 @@ class BuildozerRemote(Buildozer):
     def _posix_shell(self, chan):
         oldtty = termios.tcgetattr(stdin)
         try:
-            #tty.setraw(stdin.fileno())
-            #tty.setcbreak(stdin.fileno())
             chan.settimeout(0.0)
 
             while True:
@@ -234,7 +228,6 @@ class BuildozerRemote(Buildozer):
                             break
                         stdout.write(x)
                         stdout.flush()
-                        #print len(x), repr(x)
                     except socket.timeout:
                         pass
                 if stdin in r:
@@ -246,7 +239,7 @@ class BuildozerRemote(Buildozer):
             termios.tcsetattr(stdin, termios.TCSADRAIN, oldtty)
 
     # thanks to Mike Looijmans for this code
-    def _windows_shell(self,chan):
+    def _windows_shell(self, chan):
         import threading
 
         stdout.write("Line-buffered terminal emulation. Press F6 or ^Z to send EOF.\r\n\r\n")
@@ -274,6 +267,7 @@ class BuildozerRemote(Buildozer):
             # user hit ^Z or F6
             pass
 
+
 def main():
     try:
         BuildozerRemote().run_command(sys.argv[1:])
@@ -281,6 +275,7 @@ def main():
         pass
     except BuildozerException as error:
         Buildozer().error('%s' % error)
+
 
 if __name__ == '__main__':
     main()

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -2,6 +2,7 @@ from sys import exit
 import os
 from os.path import join
 
+
 def no_config(f):
     f.__no_config = True
     return f
@@ -9,7 +10,6 @@ def no_config(f):
 
 class Target:
     def __init__(self, buildozer):
-        super().__init__()
         self.buildozer = buildozer
         self.build_mode = 'debug'
         self.platform_update = False

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -24,7 +24,6 @@ import os
 import io
 import re
 import ast
-import sh
 from pipes import quote
 from sys import platform, executable
 from buildozer import BuildozerException, USE_COLOR
@@ -249,7 +248,7 @@ class TargetAndroid(Target):
                                                        break_on_error=False)
             is_debian_like = (returncode_dpkg == 0)
             if is_debian_like and \
-                not self.buildozer.file_exists('/usr/include/zlib.h'):
+                    not self.buildozer.file_exists('/usr/include/zlib.h'):
                 raise BuildozerException(
                     'zlib headers must be installed, '
                     'run: sudo apt-get install zlib1g-dev')
@@ -740,7 +739,7 @@ class TargetAndroid(Target):
         try:
             with open(join(self.p4a_dir, "setup.py")) as fd:
                 setup = fd.read()
-                deps = re.findall("^\s*install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
+                deps = re.findall(r"^\s*install_reqs = (\[[^\]]*\])", setup, re.DOTALL | re.MULTILINE)[0]
                 deps = ast.literal_eval(deps)
         except IOError:
             self.buildozer.error('Failed to read python-for-android setup.py at {}'.format(
@@ -768,7 +767,7 @@ class TargetAndroid(Target):
             'P4A_{}_DIR'.format(name[20:]): realpath(expanduser(value))
             for name, value in self.buildozer.config.items('app')
             if name.startswith('requirements.source.')
-            }
+        }
         if source_dirs:
             self.buildozer.environ.update(source_dirs)
             self.buildozer.info('Using custom source dirs:\n    {}'.format(
@@ -1055,12 +1054,12 @@ class TargetAndroid(Target):
             build_cmd += [('--add-compile-option', option)]
 
         # android.add_gradle_repositories
-        repos = config.getlist('app','android.add_gradle_repositories', [])
+        repos = config.getlist('app', 'android.add_gradle_repositories', [])
         for repo in repos:
             build_cmd += [('--add-gradle-repository', repo)]
 
         # android packaging options
-        pkgoptions = config.getlist('app','android.add_packaging_options', [])
+        pkgoptions = config.getlist('app', 'android.add_packaging_options', [])
         for pkgoption in pkgoptions:
             build_cmd += [('--add-packaging-option', pkgoption)]
 
@@ -1114,7 +1113,7 @@ class TargetAndroid(Target):
             build_cmd += [("--ouya-icon", join(self.buildozer.root_dir,
                                                ouya_icon))]
 
-        if config.getdefault('app','p4a.bootstrap','sdl2') != 'service_only':
+        if config.getdefault('app', 'p4a.bootstrap', 'sdl2') != 'service_only':
             # add orientation
             orientation = config.getdefault('app', 'orientation', 'landscape')
             if orientation == 'all':
@@ -1359,6 +1358,7 @@ class TargetAndroid(Target):
 def get_target(buildozer):
     buildozer.targetname = "android"
     return TargetAndroid(buildozer)
+
 
 def generate_dist_folder_name(base_dist_name, arch_names=None):
     """Generate the distribution folder name to use, based on a

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -59,6 +59,7 @@ li { padding: 1em; }
 </html>
 '''
 
+
 class TargetIos(Target):
     targetname = "ios"
 
@@ -113,7 +114,7 @@ class TargetIos(Target):
 
         # we need to extract the requirements that kivy-ios knows about
         available_modules = self.get_available_packages()
-        onlyname = lambda x: x.split('==')[0]
+        onlyname = lambda x: x.split('==')[0]  # noqa: E731 do not assign a lambda expression, use a def
         ios_requirements = [x for x in app_requirements if onlyname(x) in
                             available_modules]
 
@@ -400,6 +401,7 @@ class TargetIos(Target):
         if save:
             with open(password_file, 'wb') as fd:
                 fd.write(password.encode())
+
 
 def get_target(buildozer):
     return TargetIos(buildozer)

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -6,24 +6,9 @@ import sys
 if sys.platform != 'darwin':
     raise NotImplementedError('This will only work on osx')
 
-#Global variables
-
-#Global imports
-import traceback
-import os
-import io
-from pipes import quote
-from sys import platform, executable
-from buildozer import BuildozerException
 from buildozer.target import Target
-from os import environ
-from os.path import (exists, join, realpath, expanduser,
-    basename, relpath, abspath, dirname)
-from shutil import copyfile
-from glob import glob
+from os.path import exists, join, abspath, dirname
 from subprocess import check_call, check_output
-
-from buildozer.libs.version import parse
 
 
 class TargetOSX(Target):
@@ -32,7 +17,7 @@ class TargetOSX(Target):
     def ensure_sdk(self):
         self.buildozer.info('Check if kivy-sdk-packager exists')
         if exists(
-            join(self.buildozer.platform_dir, 'kivy-sdk-packager-master')):
+                join(self.buildozer.platform_dir, 'kivy-sdk-packager-master')):
             self.buildozer.info(
                     'kivy-sdk-packager found at '
                 '{}'.format(self.buildozer.platform_dir))
@@ -122,7 +107,7 @@ class TargetOSX(Target):
         author = bc.getdefault('app', 'author', '')
 
         self.buildozer.info('Create {}.app'.format(package_name))
-        cwd = join(self.buildozer.platform_dir,'kivy-sdk-packager-master', 'osx')
+        cwd = join(self.buildozer.platform_dir, 'kivy-sdk-packager-master', 'osx')
         # remove kivy from app_deps
         app_deps = [a for a in app_deps.split('\n') if not a.startswith('#') and a not in ['kivy', '']]
 
@@ -139,7 +124,6 @@ class TargetOSX(Target):
              '--bundlename={}'.format(title),
              '--bundleid={}'.format(domain),
              '--bundleversion={}'.format(version),
-             #'--deps={}'.format(','.join(app_deps)),
              '--displayname={}'.format(title)
              ]
         if icon:
@@ -174,7 +158,7 @@ class TargetOSX(Target):
         #
         self.buildozer.environ.update({
             'PACKAGES_PATH': self.buildozer.global_packages_dir,
-            })
+        })
 
     def get_custom_commands(self):
         result = []

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pytest
 import codecs
 import tempfile

--- a/tox.ini
+++ b/tox.ini
@@ -21,22 +21,12 @@ commands = flake8 buildozer/ tests/
 ignore =
     E121, # continuation line under-indented for hanging indent
     E122, # continuation line missing indentation or outdented
-    E123, # closing bracket does not match indentation of opening bracket's line
-    E125, # continuation line with same indent as next logical line
     E126, # continuation line over-indented for hanging indent
     E127, # continuation line over-indented for visual indent
     E128, # continuation line under-indented for visual indent
     E131, # continuation line unaligned for hanging indent
-    E231, # missing whitespace after ','
-    E265, # block comment should start with '# '
-    E302, # expected 2 blank lines, found 1
-    E305, # expected 2 blank lines after class or function definition, found 1
     E402, # module level import not at top of file
     E501, # line too long
     E722, # do not use bare 'except'
-    E731, # do not assign a lambda expression, use a def
-    F401, # imported but unused
-    F821, # undefined name
     W503, # line break before binary operator
-    W504, # line break after binary operator
-    W605  # invalid escape sequence
+    W504 # line break after binary operator


### PR DESCRIPTION
Linter fixes:
- E123 closing bracket does not match indentation of opening bracket's line
- E125 continuation line with same indent as next logical line
- E231 missing whitespace after ','
- E265 block comment should start with '# '
- E302 expected 2 blank lines, found 1
- E305 expected 2 blank lines after class or function definition, found 1
- E731 do not assign a lambda expression, use a def
- F401 imported but unused
- F821 undefined name
- W605 invalid escape sequence

Also removes a Python 2 reference from the README.md