### PR TITLE
Content providers

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -194,6 +194,10 @@ fullscreen = 0
 # (str) launchMode to set for the main activity
 #android.manifest.launch_mode = standard
 
+# (list) XML files to add to the src/main/res/xml subdirectory of the build
+# such files are usually referenced in the manifest, e.g. to specifiy file paths for a content provider
+#android.add_xml_resources =
+
 # (list) Android additional libraries to copy into libs/armeabi
 #android.add_libs_armeabi = libs/android/*.so
 #android.add_libs_armeabi_v7a = libs/android-v7/*.so

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -188,6 +188,9 @@ fullscreen = 0
 # (str) XML file to include as an intent filters in <activity> tag
 #android.manifest.intent_filters =
 
+# (str) XML file to include at the end of the <application> tag
+#android.manifest.content_providers =
+
 # (str) launchMode to set for the main activity
 #android.manifest.launch_mode = standard
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1145,6 +1145,13 @@ class TargetAndroid(Target):
             build_cmd += [('--content-providers', join(self.buildozer.root_dir,
                                                        content_providers))]
 
+        # extra xml resources
+        add_xml_resources = config.getlist(
+            'app', 'android.manifest.add_xml_resources', [])
+        for xml_resource in add_xml_resources:
+            build_cmd += [('--add-xml-resource', join(self.buildozer.root_dir,
+                                                      xml_resource))]
+
         # activity launch mode
         launch_mode = config.getdefault(
             'app', 'android.manifest.launch_mode', '')

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1147,7 +1147,7 @@ class TargetAndroid(Target):
 
         # extra xml resources
         add_xml_resources = config.getlist(
-            'app', 'android.manifest.add_xml_resources', [])
+            'app', 'android.add_xml_resources', [])
         for xml_resource in add_xml_resources:
             build_cmd += [('--add-xml-resource', join(self.buildozer.root_dir,
                                                       xml_resource))]

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1138,6 +1138,13 @@ class TargetAndroid(Target):
             build_cmd += [("--intent-filters", join(self.buildozer.root_dir,
                                                     intent_filters))]
 
+        # content providers
+        content_providers = config.getdefault(
+            'app', 'android.manifest.content_providers', '')
+        if content_providers:
+            build_cmd += [('--content-providers', join(self.buildozer.root_dir,
+                                                       content_providers))]
+
         # activity launch mode
         launch_mode = config.getdefault(
             'app', 'android.manifest.launch_mode', '')


### PR DESCRIPTION
This PR complements kivy/python-for-android#2200, adding two config options that can be used in `buildozer.spec`:

- `android.manifest.content_providers` expects a path to a file, the contents of which will be inserted into the `<application>` tag of the Android manifest.
- `android.add_xml_resources` expects a list of file paths to be copied into the `src/main/res/xml` subdirectory of the build, so that they can be referenced in the Android manifest.

As an example of how it would look like from the viewpoint of a developer using Kivy, one may take a look at pavelsof/mobile-wormhole@d0c100e1c77a73d3a2864a000ee6169fbaffdb69.