### PR TITLE
:sparkles: Adds p4a --numeric-version support

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -221,6 +221,10 @@ fullscreen = 0
 # (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
 android.arch = armeabi-v7a
 
+# (int) overrides automatic versionCode computation (used in build.gradle)
+# this is not the same as app version and should only be edited if you know what you're doing
+# android.numeric_version = 1
+
 #
 # Python for android (p4a) specific
 #

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1143,6 +1143,11 @@ class TargetAndroid(Target):
         if launch_mode:
             build_cmd += [("--activity-launch-mode", launch_mode)]
 
+        # numeric version
+        numeric_version = config.getdefault('app', 'android.numeric_version')
+        if numeric_version:
+            build_cmd += [("--numeric-version", numeric_version)]
+
         # build only in debug right now.
         if self.build_mode == 'debug':
             build_cmd += [("debug", )]


### PR DESCRIPTION
This flag is available in p4a and can be useful to have buildozer side too.
Also refs #1079