### PR TITLE
:white_check_mark: Also integration test on macOS

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -45,7 +45,12 @@ jobs:
       run: docker run kivy/buildozer --version
 
   Integration:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'macOs-latest'
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Setup python
       uses: actions/setup-python@v2
@@ -60,8 +65,17 @@ jobs:
     - run: buildozer init
     - name: SDK, NDK and p4a download
       run: |
-        sed "s/# android.accept_sdk_license = False/android.accept_sdk_license = True/" -i buildozer.spec
+        sed -i.bak "s/# android.accept_sdk_license = False/android.accept_sdk_license = True/" buildozer.spec
         buildozer android p4a -- --help
+    # Install OS specific dependencies
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt -y install automake
+    - name: Install macOS dependencies
+      if: matrix.os == 'macOS-latest'
+      run: |
+        brew install automake
+        sudo ln -sfn /usr/local/opt/openssl /usr/local/ssl
     - name: buildozer android debug
       run: |
         touch main.py

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,7 @@ First, install the buildozer project with::
 Targeting Android
 -----------------
 
-Android on Ubuntu 18.04 (64bit)
+Android on Ubuntu 20.04 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (expected to work as well in later version, but only regularly tested in the latest LTS)
@@ -26,6 +26,20 @@ Android on Ubuntu 18.04 (64bit)
 
     # add the following line at the end of your ~/.bashrc file
     export PATH=$PATH:~/.local/bin/
+
+
+Android on macOS
+~~~~~~~~~~~~~~~~
+
+::
+
+    brew install openssl
+    sudo ln -sfn /usr/local/opt/openssl /usr/local/ssl
+    brew install pkg-config autoconf automake
+    python3 -m pip install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
+
+    # add the following line at the end of your `~/.bashrc` file
+    export PATH=$PATH:~/Library/Python/3.7/bin
 
 
 TroubleShooting
@@ -72,4 +86,4 @@ Install pip and virtualenv
 
 ::
 
-    python -m pip install --user --upgrade pip virtualenv kivy-ios
+    python3 -m pip install --user --upgrade pip virtualenv kivy-ios


### PR DESCRIPTION
Note the `sed` expression got updated to work for both OS.
Also workaround openssl lib install on macOS, the error was:
```
  RAN: /bin/bash -c 'venv/bin/pip install Cython'

  STDOUT:
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
Collecting Cython
  WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/cython/
  WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/cython/
  WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/cython/
  WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/cython/
  WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/cython/
  Could not fetch URL https://pypi.org/simple/cython/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/cython/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
  ERROR: Could not find a version that satisfies the requirement Cython (from versions: none)
ERROR: No matching distribution found for Cython
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
```