### PR TITLE
:arrow_up: Migrates to Command line tools

### DIFF
--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -253,10 +253,12 @@ class TestTargetAndroid:
         assert m_file_exists.call_args_list == [
             mock.call(self.target_android.android_sdk_dir)
         ]
-        archive = "sdk-tools-{platform}-4333796.zip".format(platform=platform)
+        platform_map = {"linux": "linux", "darwin": "mac"}
+        platform = platform_map[platform]
+        archive = "commandlinetools-{platform}-6514223_latest.zip".format(platform=platform)
         assert m_download.call_args_list == [
             mock.call(
-                "http://dl.google.com/android/repository/",
+                "https://dl.google.com/android/repository/",
                 archive,
                 cwd=mock.ANY,
             )


### PR DESCRIPTION
The SDK Tools package is deprecated and no longer receiving updates:
https://developer.android.com/studio/releases/sdk-tools
Also drops the "tools" package install as it's considered obsolete.

Migrates to command line tools:
https://developer.android.com/studio#cmdline-tools
https://developer.android.com/studio/command-line

Makes it possible to use both OpenJDK 8 and more recent versions.
Tested successfully in Arch with OpenJDK 10.