### PR TITLE
Declare Buildozer to be Stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
     include_package_data=True,
     install_requires=['pexpect', 'virtualenv', 'sh'],
     classifiers=[
-        'Development Status :: 4 - Beta', 'Intended Audience :: Developers',
+        'Development Status :: 5 - Production/Stable', 
+        'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
According to @AndreMiras ([ref](https://discord.com/channels/423249981340778496/490493814281338890/719947159570612264)), buildozer should be considered to be stable.

This edit lets PyPI know.

(This feels like it deserves a little fanfare: 🥳🎉 Congrats and thanks to you all for your work!)