### PR TITLE
SafeConfigParser deprecated.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -28,7 +28,7 @@ from fnmatch import fnmatch
 from pprint import pformat
 
 from urllib.request import FancyURLopener
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 try:
     import fcntl
 except ImportError:
@@ -113,7 +113,7 @@ class Buildozer:
         self.state = None
         self.build_id = None
         self.config_profile = ''
-        self.config = SafeConfigParser(allow_no_value=True)
+        self.config = ConfigParser(allow_no_value=True)
         self.config.optionxform = lambda value: value
         self.config.getlist = self._get_config_list
         self.config.getlistvalues = self._get_config_list_values

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -21,10 +21,7 @@ from sys import stdout, stdin, exit
 from select import select
 from os.path import join, expanduser, realpath, exists, splitext
 from os import makedirs, walk, getcwd
-try:
-    from configparser import SafeConfigParser
-except ImportError:
-    from ConfigParser import SafeConfigParser
+from configparser import ConfigParser
 try:
     import termios
     has_termios = True
@@ -138,7 +135,7 @@ class BuildozerRemote(Buildozer):
 
         # create custom buildozer.spec
         self.info('Create custom buildozer.spec')
-        config = SafeConfigParser()
+        config = ConfigParser()
         config.read('buildozer.spec')
         config.set('app', 'source.dir', 'app')
 

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -13,27 +13,25 @@ You need paramiko to make it work.
 
 __all__ = ["BuildozerRemote"]
 
-import socket
-import sys
-from buildozer import (
-    Buildozer, BuildozerCommandException, BuildozerException, __version__)
-from sys import stdout, stdin, exit
-from select import select
-from os.path import join, expanduser, realpath, exists, splitext
+from configparser import ConfigParser
 from os import makedirs, walk, getcwd
+from os.path import join, expanduser, realpath, exists, splitext
+from select import select
+import socket
+from sys import argv, stdout, stdin, exit
+
 try:
-    from configparser import SafeConfigParser
+    import paramiko
 except ImportError:
-    from ConfigParser import SafeConfigParser
+    print('Paramiko missing: pip install paramiko')
 try:
     import termios
     has_termios = True
 except ImportError:
     has_termios = False
-try:
-    import paramiko
-except ImportError:
-    print('Paramiko missing: pip install paramiko')
+
+from buildozer import (
+    Buildozer, BuildozerCommandException, BuildozerException, __version__)
 
 
 class BuildozerRemote(Buildozer):
@@ -138,7 +136,7 @@ class BuildozerRemote(Buildozer):
 
         # create custom buildozer.spec
         self.info('Create custom buildozer.spec')
-        config = SafeConfigParser()
+        config = ConfigParser()
         config.read('buildozer.spec')
         config.set('app', 'source.dir', 'app')
 
@@ -270,7 +268,7 @@ class BuildozerRemote(Buildozer):
 
 def main():
     try:
-        BuildozerRemote().run_command(sys.argv[1:])
+        BuildozerRemote().run_command(argv[1:])
     except BuildozerCommandException:
         pass
     except BuildozerException as error:

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -13,25 +13,27 @@ You need paramiko to make it work.
 
 __all__ = ["BuildozerRemote"]
 
-from configparser import ConfigParser
-from os import makedirs, walk, getcwd
-from os.path import join, expanduser, realpath, exists, splitext
-from select import select
 import socket
-from sys import argv, stdout, stdin, exit
-
+import sys
+from buildozer import (
+    Buildozer, BuildozerCommandException, BuildozerException, __version__)
+from sys import stdout, stdin, exit
+from select import select
+from os.path import join, expanduser, realpath, exists, splitext
+from os import makedirs, walk, getcwd
 try:
-    import paramiko
+    from configparser import SafeConfigParser
 except ImportError:
-    print('Paramiko missing: pip install paramiko')
+    from ConfigParser import SafeConfigParser
 try:
     import termios
     has_termios = True
 except ImportError:
     has_termios = False
-
-from buildozer import (
-    Buildozer, BuildozerCommandException, BuildozerException, __version__)
+try:
+    import paramiko
+except ImportError:
+    print('Paramiko missing: pip install paramiko')
 
 
 class BuildozerRemote(Buildozer):
@@ -136,7 +138,7 @@ class BuildozerRemote(Buildozer):
 
         # create custom buildozer.spec
         self.info('Create custom buildozer.spec')
-        config = ConfigParser()
+        config = SafeConfigParser()
         config.read('buildozer.spec')
         config.set('app', 'source.dir', 'app')
 
@@ -268,7 +270,7 @@ class BuildozerRemote(Buildozer):
 
 def main():
     try:
-        BuildozerRemote().run_command(argv[1:])
+        BuildozerRemote().run_command(sys.argv[1:])
     except BuildozerCommandException:
         pass
     except BuildozerException as error:


### PR DESCRIPTION
SafeConfigParser was renamed to ConfigParser in Python 3.2. Use of it in Python 3.7 gives a DeprecationWarning.

As Buildozer is not supported at below Python 3.2, simply replaced all mentions.

Warning is no longer issued.