### PR TITLE
Cleanup of imports

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -8,32 +8,33 @@ Generic Python packager for Android / iOS. Desktop later.
 
 __version__ = '1.2.0.dev0'
 
-import os
-import re
-import sys
-import select
 import codecs
-import textwrap
-import warnings
-from buildozer.jsonstore import JsonStore
-from sys import stdout, stderr, exit
-from re import search
-from os.path import join, exists, dirname, realpath, splitext, expanduser
-from subprocess import Popen, PIPE
-from os import environ, unlink, walk, sep, listdir, makedirs
-from copy import copy
-from shutil import copyfile, rmtree, copytree, move
-from fnmatch import fnmatch
-
-from pprint import pformat
-
-from urllib.request import FancyURLopener
 from configparser import ConfigParser
+from copy import copy
+from fnmatch import fnmatch
+import os
+from os import environ, unlink, walk, sep, listdir, makedirs, chdir
+from os.path import join, exists, dirname, realpath, splitext, expanduser, isdir
+from pprint import pformat
+import re
+from re import search
+import select
+import sys
+from sys import stdout, stderr, exit
+from subprocess import Popen, PIPE
+from shutil import copyfile, rmtree, copytree, move
+import textwrap
+from urllib.request import FancyURLopener
+import warnings
+
+from buildozer.jsonstore import JsonStore
+
 try:
     import fcntl
 except ImportError:
     # on windows, no fcntl
     fcntl = None
+
 try:
     # if installed, it can give color to windows as well
     import colorama
@@ -569,7 +570,7 @@ class Buildozer:
             source = join(cwd, source)
             target = join(cwd, target)
         self.debug('Rename {0} to {1}'.format(source, target))
-        if not os.path.isdir(os.path.dirname(target)):
+        if not isdir(dirname(target)):
             self.error(('Rename {0} to {1} fails because {2} is not a '
                         'directory').format(source, target, target))
         move(source, target)
@@ -605,14 +606,14 @@ class Buildozer:
 
     def file_copytree(self, src, dest):
         print('copy {} to {}'.format(src, dest))
-        if os.path.isdir(src):
-            if not os.path.isdir(dest):
-                os.makedirs(dest)
-            files = os.listdir(src)
+        if isdir(src):
+            if not isdir(dest):
+                makedirs(dest)
+            files = listdir(src)
             for f in files:
                 self.file_copytree(
-                    os.path.join(src, f),
-                    os.path.join(dest, f))
+                    join(src, f),
+                    join(dest, f))
         else:
             copyfile(src, dest)
 
@@ -1087,7 +1088,7 @@ class Buildozer:
             from SimpleHTTPServer import SimpleHTTPRequestHandler
             from SocketServer import TCPServer
 
-        os.chdir(self.bin_dir)
+        chdir(self.bin_dir)
         handler = SimpleHTTPRequestHandler
         httpd = TCPServer(("", SIMPLE_HTTP_SERVER_PORT), handler)
         print("Serving via HTTP at port {}".format(SIMPLE_HTTP_SERVER_PORT))
@@ -1216,7 +1217,7 @@ def set_config_token_from_env(section, token, config):
     '''
     env_var_name = ''.join([section.upper(), '_',
                             token.upper().replace('.', '_')])
-    env_var = os.environ.get(env_var_name)
+    env_var = environ.get(env_var_name)
     if env_var is None:
         return False
     config.set(section, token, env_var)

--- a/buildozer/scripts/client.py
+++ b/buildozer/scripts/client.py
@@ -5,6 +5,7 @@ Main Buildozer client
 '''
 
 import sys
+
 from buildozer import Buildozer, BuildozerCommandException, BuildozerException
 
 

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -13,15 +13,13 @@ You need paramiko to make it work.
 
 __all__ = ["BuildozerRemote"]
 
-import socket
-import sys
-from buildozer import (
-    Buildozer, BuildozerCommandException, BuildozerException, __version__)
-from sys import stdout, stdin, exit
-from select import select
+from configparser import ConfigParser
 from os.path import join, expanduser, realpath, exists, splitext
 from os import makedirs, walk, getcwd
-from configparser import ConfigParser
+from select import select
+import socket
+from sys import argv, stdout, stdin, exit
+
 try:
     import termios
     has_termios = True
@@ -31,6 +29,9 @@ try:
     import paramiko
 except ImportError:
     print('Paramiko missing: pip install paramiko')
+
+from buildozer import (
+    Buildozer, BuildozerCommandException, BuildozerException, __version__)
 
 
 class BuildozerRemote(Buildozer):
@@ -267,7 +268,7 @@ class BuildozerRemote(Buildozer):
 
 def main():
     try:
-        BuildozerRemote().run_command(sys.argv[1:])
+        BuildozerRemote().run_command(argv[1:])
     except BuildozerCommandException:
         pass
     except BuildozerException as error:

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -2,15 +2,16 @@
 iOS target, based on kivy-ios project
 '''
 
-import sys
-if sys.platform != 'darwin':
-    raise NotImplementedError('Windows platform not yet working for Android')
-
+from getpass import getpass
+from os.path import join, basename, expanduser, realpath
 import plistlib
+import sys
+
 from buildozer import BuildozerCommandException
 from buildozer.target import Target, no_config
-from os.path import join, basename, expanduser, realpath
-from getpass import getpass
+
+if sys.platform != 'darwin':
+    raise NotImplementedError('Windows platform not yet working for Android')
 
 
 PHP_TEMPLATE = '''

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -2,13 +2,14 @@
 OSX target, based on kivy-sdk-packager
 '''
 
-import sys
-if sys.platform != 'darwin':
-    raise NotImplementedError('This will only work on osx')
-
-from buildozer.target import Target
 from os.path import exists, join, abspath, dirname
 from subprocess import check_call, check_output
+import sys
+
+from buildozer.target import Target
+
+if sys.platform != 'darwin':
+    raise NotImplementedError('This will only work on osx')
 
 
 class TargetOSX(Target):

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@
 Buildozer
 '''
 
-import sys
-from setuptools import setup
-from os.path import dirname, join
 import codecs
-import os
-import re
 import io
+import os
+from os.path import dirname, join
+import re
+from setuptools import setup
+import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/scripts/test_client.py
+++ b/tests/scripts/test_client.py
@@ -1,8 +1,9 @@
 import sys
 import unittest
+from unittest import mock
+
 from buildozer import BuildozerCommandException
 from buildozer.scripts import client
-from unittest import mock
 
 
 class TestClient(unittest.TestCase):

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -1,9 +1,9 @@
-import re
-import os
 import codecs
 import unittest
 import buildozer as buildozer_module
 from buildozer import Buildozer
+import re
+import os
 from six import StringIO
 import tempfile
 from unittest import mock


### PR DESCRIPTION
PEP8 states:

Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants.

Imports should be grouped in the following order:
1. Standard library imports.
2. Related third party imports.
3. Local application/library specific imports.
You should put a blank line between each group of imports.

---

Followed this convention.
Additionally sorted alphabetically, to help find cases of double imports.

Where there were double imports:
- didn't go as far as removing them, but ensured all references to explicitly-named imports were using them.
- removed `import sys` (in remote.py)

android.py imported platform.executable which was then hidden by a local with the same identifier. Renamed the local to avoid aliasing.