### PR TITLE
:green_apple: Improves iOS support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup environment
       run: |
         pip install -e .
-        pip install Cython==0.29.19
+        pip install Cython
     - run: buildozer --help
     - run: buildozer init
     - name: SDK, NDK and p4a download

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,24 @@
+on: [push, pull_request]
+name: iOS
+jobs:
+  Integration:
+    runs-on: macOS-latest
+    steps:
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - uses: actions/checkout@v2
+    - name: Setup environment
+      run: |
+        pip install -e .
+        pip install Cython cookiecutter pbxproj
+    - run: buildozer --help
+    - run: buildozer init
+    - name: Install dependencies
+      run: |
+        brew install autoconf automake libtool pkg-config
+    - name: buildozer ios debug
+      run: |
+        touch main.py
+        buildozer ios debug

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Buildozer
 =========
 
-[![Build](https://github.com/kivy/buildozer/workflows/Tests/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3ATests)
-[![Build](https://github.com/kivy/buildozer/workflows/Android/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AAndroid)
+[![Tests](https://github.com/kivy/buildozer/workflows/Tests/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3ATests)
+[![Android](https://github.com/kivy/buildozer/workflows/Android/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AAndroid)
+[![iOS](https://github.com/kivy/buildozer/workflows/iOS/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AiOS)
 [![Coverage Status](https://coveralls.io/repos/github/kivy/buildozer/badge.svg)](https://coveralls.io/github/kivy/buildozer)
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -22,7 +22,7 @@ source.include_exts = py,png,jpg,kv,atlas
 #source.exclude_exts = spec
 
 # (list) List of directory to exclude (let empty to not exclude anything)
-#source.exclude_dirs = tests, bin
+#source.exclude_dirs = tests, bin, venv
 
 # (list) List of exclusions using pattern matching
 #source.exclude_patterns = license,images/*/*.jpg
@@ -263,7 +263,10 @@ ios.kivy_ios_branch = master
 #ios.ios_deploy_dir = ../ios_deploy
 # Or specify URL and branch
 ios.ios_deploy_url = https://github.com/phonegap/ios-deploy
-ios.ios_deploy_branch = 1.7.0
+ios.ios_deploy_branch = 1.10.0
+
+# (bool) Whether or not to sign the code
+ios.codesign.allowed = false
 
 # (str) Name of the certificate to use for signing the debug version
 # Get a list of available identities: buildozer ios list_identities


### PR DESCRIPTION
Updates & fixes support for iOS target, covers the following:
- Build integration test
- Updates to new kivy-ios structure
- Bumps to ios-deploy 1.10.0 (`make` replaced by `xcodebuild`)
- Makes it possible to toggle code signing (now disabled by default)

Note this is the first iteration of a longer serie.
Subsequent pull requests will try to improve the following:
- code signing process (toggle not fully integrated)
- actual deployment (not yet tested)
- unit tests (mainly `buildozer/targets/ios.py`)
- other forms of technical debt