### PR TITLE
:white_check_mark: Unit test ios target

### DIFF
--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -3,9 +3,6 @@ iOS target, based on kivy-ios project
 '''
 
 import sys
-if sys.platform != 'darwin':
-    raise NotImplementedError('Windows platform not yet working for Android')
-
 import plistlib
 from buildozer import BuildozerCommandException
 from buildozer.target import Target, no_config
@@ -64,6 +61,8 @@ class TargetIos(Target):
     targetname = "ios"
 
     def check_requirements(self):
+        if sys.platform != "darwin":
+            raise NotImplementedError("Only macOS is supported for iOS target")
         checkbin = self.buildozer.checkbin
         cmd = self.buildozer.cmd
         executable = sys.executable or 'python'

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -1,0 +1,80 @@
+import sys
+import tempfile
+from unittest import mock
+
+import pytest
+
+from buildozer.targets.ios import TargetIos
+from tests.targets.utils import init_buildozer, patch_buildozer_checkbin
+
+
+def init_target(temp_dir, options=None):
+    buildozer = init_buildozer(temp_dir, "ios", options)
+    return TargetIos(buildozer)
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin", reason="Only macOS is supported for target iOS"
+)
+class TestTargetIos:
+    def setup_method(self):
+        """
+        Create a temporary directory that will contain the spec file and will
+        serve as the root_dir.
+        """
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tear_method(self):
+        """
+        Remove the temporary directory created in self.setup_method.
+        """
+        self.temp_dir.cleanup()
+
+    def test_init(self):
+        """Tests init defaults."""
+        target = init_target(self.temp_dir)
+        assert target.targetname == "ios"
+        assert target.code_signing_allowed == "CODE_SIGNING_ALLOWED=NO"
+        assert target.build_mode == "debug"
+        assert target.platform_update is False
+
+    def test_check_requirements(self):
+        """Basic tests for the check_requirements() method."""
+        target = init_target(self.temp_dir)
+        buildozer = target.buildozer
+        assert not hasattr(target, "adb_cmd")
+        assert not hasattr(target, "javac_cmd")
+        assert "PATH" not in buildozer.environ
+        with patch_buildozer_checkbin() as m_checkbin:
+            target.check_requirements()
+        assert m_checkbin.call_args_list == [
+            mock.call("Xcode xcodebuild", "xcodebuild"),
+            mock.call("Xcode xcode-select", "xcode-select"),
+            mock.call("Git git", "git"),
+            mock.call("Cython cython", "cython"),
+            mock.call("pkg-config", "pkg-config"),
+            mock.call("autoconf", "autoconf"),
+            mock.call("automake", "automake"),
+            mock.call("libtool", "libtool"),
+        ]
+        assert target._toolchain_cmd.endswith("toolchain.py ")
+        assert target._xcodebuild_cmd == "xcodebuild "
+
+    def test_check_configuration_tokens(self):
+        """Basic tests for the check_configuration_tokens() method."""
+        target = init_target(self.temp_dir, {"ios.codesign.allowed": "yes"})
+        with mock.patch(
+            "buildozer.targets.android.Target.check_configuration_tokens"
+        ) as m_check_configuration_tokens, mock.patch(
+            "buildozer.targets.ios.TargetIos._get_available_identities"
+        ) as m_get_available_identities:
+            target.check_configuration_tokens()
+        assert m_get_available_identities.call_args_list == [mock.call()]
+        assert m_check_configuration_tokens.call_args_list == [
+            mock.call(
+                [
+                    '[app] "ios.codesign.debug" key missing, you must give a certificate name to use.',
+                    '[app] "ios.codesign.release" key missing, you must give a certificate name to use.',
+                ]
+            )
+        ]

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -1,0 +1,54 @@
+import os
+import re
+from unittest import mock
+
+import buildozer as buildozer_module
+from buildozer import Buildozer
+
+
+def patch_buildozer(method):
+    return mock.patch("buildozer.Buildozer.{method}".format(method=method))
+
+
+def patch_buildozer_checkbin():
+    return patch_buildozer("checkbin")
+
+
+def default_specfile_path():
+    return os.path.join(os.path.dirname(buildozer_module.__file__), "default.spec")
+
+
+def init_buildozer(temp_dir, target, options=None):
+    """
+    Create a buildozer.spec file in the temporary directory and init the
+    Buildozer instance.
+
+    The optional argument can be used to overwrite the config options in
+    the buildozer.spec file, e.g.:
+
+        init_buildozer({'title': 'Test App'})
+
+    will replace line 4 of the default spec file.
+    """
+    if options is None:
+        options = {}
+
+    spec_path = os.path.join(temp_dir.name, "buildozer.spec")
+
+    with open(default_specfile_path()) as f:
+        default_spec = f.readlines()
+
+    spec = []
+    for line in default_spec:
+        if line.strip():
+            match = re.search(r"[#\s]?([a-z_\.]+)", line)
+            key = match and match.group(1)
+            if key in options:
+                line = "{} = {}\n".format(key, options[key])
+
+        spec.append(line)
+
+    with open(spec_path, "w") as f:
+        f.writelines(spec)
+
+    return Buildozer(filename=spec_path, target=target)


### PR DESCRIPTION
- basic ios target test
- refactors existing android test for code sharing
- changes `call_build_package()` to simple function

Grows `buildozer/targets/ios.py` coverage from 11% to 24%.
This setups the canvas for more tests to come later.