### PR TITLE
:white_check_mark: Increases ios target test coverage

### DIFF
--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -9,19 +9,13 @@ from tests.targets.utils import (
     init_buildozer,
     patch_buildozer,
     patch_buildozer_checkbin,
+    patch_buildozer_cmd,
+    patch_buildozer_file_exists,
 )
-
-
-def patch_buildozer_cmd():
-    return patch_buildozer("cmd")
 
 
 def patch_buildozer_cmd_expect():
     return patch_buildozer("cmd_expect")
-
-
-def patch_buildozer_file_exists():
-    return patch_buildozer("file_exists")
 
 
 def patch_buildozer_download():

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -10,8 +10,20 @@ def patch_buildozer(method):
     return mock.patch("buildozer.Buildozer.{method}".format(method=method))
 
 
+def patch_buildozer_cmd():
+    return patch_buildozer("cmd")
+
+
 def patch_buildozer_checkbin():
     return patch_buildozer("checkbin")
+
+
+def patch_buildozer_file_exists():
+    return patch_buildozer("file_exists")
+
+
+def patch_buildozer_error():
+    return patch_buildozer("error")
 
 
 def default_specfile_path():


### PR DESCRIPTION
This is a follow-up for #1160 and #1168.
Addresses the following:
- grows `buildozer/targets/ios.py` target coverage from 24% to 56%
- fixes `AttributeError` on `TargetIos` error call

Next up should be improving:
- code signing process (toggle off not fully integrated)
- actual deployment (not yet tested)
- further increase `buildozer/targets/ios.py` test coverage