### PR TITLE
Fixes heading for iOS target

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -70,7 +70,7 @@ See the dedicated `p4a troubleshooting documentation
 
 
 Targeting IOS
-~~~~~~~~~~~~~
+-------------
 
 Install XCode and command line tools (through the AppStore)
 


### PR DESCRIPTION
Noticed the "Targeting iOS" heading was subordinate to "Targeting Android". This simple change promotes the iOS heading to the same level as Android.