### PR TITLE
Add link to GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ A Dockerfile is available to use buildozer through a Docker environment.
       docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
 
 
+## Buildozer GitHub action
+
+Use [ArtemSBulgakov/buildozer-action@v1](https://github.com/ArtemSBulgakov/buildozer-action)
+to build your packages automatically on push or pull request.
+See [full workflow example](https://github.com/ArtemSBulgakov/buildozer-action#full-workflow).
+
+
 ## Examples of Buildozer commands
 
 ```


### PR DESCRIPTION
I made GitHub action to build packages for Android with Buildozer. You can find it [here](https://github.com/ArtemSBulgakov/buildozer-action).

I want to add a link to the Readme because many people don't know that there is such way to build applications.