### PR TITLE
Add android.backup_rules parameter to buildozer.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -231,6 +231,9 @@ android.arch = armeabi-v7a
 # (bool) enables Android auto backup feature (Android API >=23)
 android.allow_backup = True
 
+# (str) XML file for custom backup rules (see official auto backup documentation)
+# android.backup_rules =
+
 #
 # Python for android (p4a) specific
 #

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1163,6 +1163,12 @@ class TargetAndroid(Target):
         if not allow_backup:
             build_cmd += [('--allow-backup', 'false')]
 
+        # android.backup_rules
+        backup_rules = config.getdefault('app', 'android.backup_rules', '')
+        if backup_rules:
+            build_cmd += [("--backup-rules", join(self.buildozer.root_dir,
+                                                  backup_rules))]
+
         # build only in debug right now.
         if self.build_mode == 'debug':
             build_cmd += [("debug", )]

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -324,3 +324,29 @@ class TestTargetAndroid:
                 ]
             )
         ]
+
+    def test_backup_rules(self):
+        """The `android.backup_rules` config should be passed to `build_package()`."""
+        target_android = init_target(self.temp_dir, {
+            "android.backup_rules": "backup_rules.xml"
+        })
+        buildozer = target_android.buildozer
+        m_execute_build_package = call_build_package(target_android)
+        assert m_execute_build_package.call_args_list == [
+            mock.call(
+                [
+                    ("--name", "'My Application'"),
+                    ("--version", "0.1"),
+                    ("--package", "org.test.myapp"),
+                    ("--minsdk", "21"),
+                    ("--ndk-api", "21"),
+                    ("--private", "{buildozer_dir}/android/app".format(buildozer_dir=buildozer.buildozer_dir)),
+                    ("--android-entrypoint", "org.kivy.android.PythonActivity"),
+                    ("--android-apptheme", "@android:style/Theme.NoTitleBar"),
+                    ("--orientation", "portrait"),
+                    ("--window",),
+                    ("--backup-rules", "{root_dir}/backup_rules.xml".format(root_dir=buildozer.root_dir)),
+                    ("debug",),
+                ]
+            )
+        ]


### PR DESCRIPTION
Added support for https://github.com/kivy/python-for-android/pull/2208
(I'm not sure about using `join(self.buildozer.root_dir, backup_rules)` though)