### PR TITLE
WSL workaround now accommodates WSL 2

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -7,7 +7,7 @@ if sys.platform == 'win32':
     raise NotImplementedError('Windows platform not yet working for Android')
 
 from platform import uname
-WSL = 'Microsoft' in uname()[2]
+WSL = 'microsoft' in uname()[2].lower()
 
 ANDROID_API = '27'
 ANDROID_MINAPI = '21'


### PR DESCRIPTION
The current workaround for WSL doesn't work with WSL 2 because WSL 2 has changed the format of the uname.

Examples:

For WSL 1:
	uname()[2] = '4.4.0-18362-Microsoft'
For WSL 2:
	uname()[2] = '4.19.104-microsoft-standard'