### PR TITLE
Add option for controlling p4a distutils support, fixes #1224

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -256,6 +256,13 @@ android.allow_backup = True
 # (int) port number to specify an explicit --port= p4a argument (eg for bootstrap flask)
 #p4a.port =
 
+# Control passing the --use-setup-py vs --ignore-setup-py to p4a
+# "in the future" --use-setup-py is going to be the default behaviour in p4a, right now it is not
+# Setting this to false will pass --ignore-setup-py, true will pass --use-setup-py
+# NOTE: this is general setuptools integration, having pyproject.toml is enough, no need to generate
+# setup.py if you're using Poetry
+#p4a.setup_py = false
+
 
 #
 # iOS specific

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -260,7 +260,7 @@ android.allow_backup = True
 # "in the future" --use-setup-py is going to be the default behaviour in p4a, right now it is not
 # Setting this to false will pass --ignore-setup-py, true will pass --use-setup-py
 # NOTE: this is general setuptools integration, having pyproject.toml is enough, no need to generate
-# setup.py if you're using Poetry
+# setup.py if you're using Poetry, but you need to add "toml" to source.include_exts.
 #p4a.setup_py = false
 
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -92,6 +92,12 @@ class TargetAndroid(Target):
         if port is not None:
             self.extra_p4a_args += ' --port={}'.format(port)
 
+        setup_py = self.buildozer.config.getdefault('app', 'p4a.setup_py', False)
+        if setup_py:
+            self.extra_p4a_args += ' --use-setup-py'
+        else:
+            self.extra_p4a_args += ' --ignore-setup-py'
+
         self.warn_on_deprecated_tokens()
 
     def warn_on_deprecated_tokens(self):

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -115,7 +115,7 @@ class TestTargetAndroid:
         assert (
             target_android.extra_p4a_args == (
                 ' --color=always'
-                ' --storage-dir="{buildozer_dir}/android/platform/build-armeabi-v7a" --ndk-api=21'.format(
+                ' --storage-dir="{buildozer_dir}/android/platform/build-armeabi-v7a" --ndk-api=21 --ignore-setup-py'.format(
                 buildozer_dir=buildozer.buildozer_dir)
             )
         )


### PR DESCRIPTION
as per #1224 

  1. We need to pass the option explicitly to keep old default behaviour in the future
  2. user should be able to control whether distutils support is enabled or not.
