### PR TITLE
Add android.adb_args option

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -219,6 +219,9 @@ fullscreen = 0
 # (str) Android logcat filters to use
 #android.logcat_filters = *:S python:D
 
+# (str) Android additional adb arguments
+#android.adb_args = -H host.docker.internal
+
 # (bool) Copy library instead of making a libpymodules.so
 #android.copy_libs = 1
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -262,6 +262,12 @@ class TargetAndroid(Target):
                     'zlib headers must be installed, '
                     'run: sudo apt-get install zlib1g-dev')
 
+        # Adb arguments:
+        adb_args = self.buildozer.config.getdefault(
+            "app", "android.adb_args", None)
+        if adb_args is not None:
+            self.adb_cmd += ' ' + adb_args
+
         # Need to add internally installed ant to path for external tools
         # like adb to use
         path = [join(self.apache_ant_dir, 'bin')]


### PR DESCRIPTION
Now, if a buildozer is in a Docker container, to make it work with a Linux host you [have to pass several unobvious flags to the Docker](https://github.com/tshirtman/Buildozer-docker#installing). I wasn't able to make it work with Windows host at all.

However, it's possible to achieve the same much easier, if we could [pass a flag to the adb command](https://stackoverflow.com/a/53765498/1113207). It makes buildozer in a Docker work without any additional Docker flags and on any host (AFAIK).

The PR adds a possibility to pass an argument(s) to the adb. Uncomment the default value (`-H host.docker.internal`) and run `buildozer android deploy` from inside Docker to see the effect.