### PR TITLE
Use develop branch for automated tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,6 +23,7 @@ jobs:
     - name: SDK, NDK and p4a download
       run: |
         sed -i.bak "s/# android.accept_sdk_license = False/android.accept_sdk_license = True/" buildozer.spec
+        sed -i.bak "s/#p4a.branch = master/p4a.branch = develop/" buildozer.spec
         buildozer android p4a -- --help
     # Install OS specific dependencies
     - name: Install Linux dependencies


### PR DESCRIPTION
As discussed with @AndreMiras  in #1212 it's better to target `p4a.branch = develop` during automated tests.