### PR TITLE
Pass debug loglevel down through to python for android

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -98,6 +98,9 @@ class TargetAndroid(Target):
         else:
             self.extra_p4a_args += ' --ignore-setup-py'
 
+        if self.buildozer.log_level >= 2:
+            self.extra_p4a_args += ' --debug'
+
         self.warn_on_deprecated_tokens()
 
     def warn_on_deprecated_tokens(self):


### PR DESCRIPTION
This change makes log_level=2 show output for debugging recipes, when building them.