### PR TITLE
Revert "Add manifestPlaceholders feature"

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -235,12 +235,6 @@ android.allow_backup = True
 # (str) XML file for custom backup rules (see official auto backup documentation)
 # android.backup_rules =
 
-# (str) If you need to insert variables into your AndroidManifest.xml file,
-# you can do so with the manifestPlaceholders property.
-# This property takes a map of key-value pairs. (via a string)
-# Usage example : android.manifest_placeholders = [myCustomUrl:\"org.kivy.customurl\"]
-# android.manifest_placeholders = [:]
-
 #
 # Python for android (p4a) specific
 #

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -897,12 +897,6 @@ class TargetAndroid(Target):
             cmd.append('--depend')
             cmd.append(gradle_dependency)
 
-        # support for manifestPlaceholders
-        manifest_placeholders = self.buildozer.config.getdefault('app', 'android.manifest_placeholders', '[:]')
-        if manifest_placeholders:
-            cmd.append('--manifest-placeholders')
-            cmd.append("{}".format(manifest_placeholders))
-
         cmd.append('--arch')
         cmd.append(self._arch)
 


### PR DESCRIPTION
This reverts commit b60055cdc073238af66552164775598a84daa3a6.

This commit was making buildozer crash with anything except p4a master.

The new feature is fine, but we should presumably not pass any argument unless the user specifically adds it. Buildozer could also check that the p4a version is compatible with this argument.

I strongly think we should revert immediately and fix the change later, as this is making buildozer fail for people.