### PR TITLE
Let buildozer.spec files pin to a specific p4a commit hash

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -245,6 +245,9 @@ android.allow_backup = True
 # (str) python-for-android branch to use, defaults to master
 #p4a.branch = master
 
+# (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
+#p4a.commit = HEAD
+
 # (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
 #p4a.source_dir =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -60,6 +60,7 @@ class TargetAndroid(Target):
     p4a_directory_name = "python-for-android"
     p4a_fork = 'kivy'
     p4a_branch = 'master'
+    p4a_commit = 'HEAD'
     p4a_apk_cmd = "apk --debug --bootstrap="
     p4a_recommended_ndk_version = None
     extra_p4a_args = ''
@@ -691,6 +692,9 @@ class TargetAndroid(Target):
         p4a_branch = self.buildozer.config.getdefault(
             'app', 'p4a.branch', self.p4a_branch
         )
+        p4a_commit = self.buildozer.config.getdefault(
+            'app', 'p4a.commit', self.p4a_commit
+        )
 
         p4a_dir = self.p4a_dir
         system_p4a_dir = self.buildozer.config.getdefault('app',
@@ -744,6 +748,8 @@ class TargetAndroid(Target):
                     cmd('git fetch --tags origin {0}:{0}'.format(p4a_branch),
                         cwd=p4a_dir)
                     cmd('git checkout {}'.format(p4a_branch), cwd=p4a_dir)
+            if p4a_commit != 'HEAD':
+                cmd('git reset --hard {}'.format(p4a_commit), cwd=p4a_dir)
 
         # also install dependencies (currently, only setup.py knows about it)
         # let's extract them.


### PR DESCRIPTION
This PR adds a configuration option `p4a.commit` that can be used to require the same exact python-for-android revision for every build.  (edit: rebased to remove spurious commits)