### PR TITLE
Allow setting custom p4a URL instead of fork

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -251,7 +251,10 @@ android.allow_backup = True
 # Python for android (p4a) specific
 #
 
-# (str) python-for-android fork to use, defaults to upstream (kivy)
+# (str) python-for-android URL to use for checkout
+#p4a.url =
+
+# (str) python-for-android fork to use in case if p4a.url is not specified, defaults to upstream (kivy)
 #p4a.fork = kivy
 
 # (str) python-for-android branch to use, defaults to master

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -692,6 +692,9 @@ class TargetAndroid(Target):
         p4a_fork = self.buildozer.config.getdefault(
             'app', 'p4a.fork', self.p4a_fork
         )
+        p4a_url = self.buildozer.config.getdefault(
+            'app', 'p4a.url', 'https://github.com/{}/python-for-android.git'.format(p4a_fork)
+        )
         p4a_branch = self.buildozer.config.getdefault(
             'app', 'p4a.branch', self.p4a_branch
         )
@@ -707,20 +710,20 @@ class TargetAndroid(Target):
                 self.buildozer.error('')
                 raise BuildozerException()
         else:
-            # check that fork/branch has not been changed
+            # check that url/branch has not been changed
             if self.buildozer.file_exists(p4a_dir):
-                cur_fork = cmd(
+                cur_url = cmd(
                     'git config --get remote.origin.url',
                     get_stdout=True,
                     cwd=p4a_dir,
-                )[0].split('/')[3]
+                )[0].strip()
                 cur_branch = cmd(
                     'git branch -vv', get_stdout=True, cwd=p4a_dir
                 )[0].split()[1]
-                if any([cur_fork != p4a_fork, cur_branch != p4a_branch]):
+                if any([cur_url != p4a_url, cur_branch != p4a_branch]):
                     self.buildozer.info(
-                        "Detected old fork/branch ({}/{}), deleting...".format(
-                            cur_fork, cur_branch
+                        "Detected old url/branch ({}/{}), deleting...".format(
+                            cur_url, cur_branch
                         )
                     )
                     rmtree(p4a_dir)
@@ -729,11 +732,10 @@ class TargetAndroid(Target):
                 cmd(
                     (
                         'git clone -b {p4a_branch} --single-branch '
-                        'https://github.com/{p4a_fork}/python-for-android.git '
-                        '{p4a_dir}'
+                        '{p4a_url} {p4a_dir}'
                     ).format(
                         p4a_branch=p4a_branch,
-                        p4a_fork=p4a_fork,
+                        p4a_url=p4a_url,
                         p4a_dir=self.p4a_directory_name,
                     ),
                     cwd=self.buildozer.platform_dir,

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -693,7 +693,7 @@ class TargetAndroid(Target):
             'app', 'p4a.fork', self.p4a_fork
         )
         p4a_url = self.buildozer.config.getdefault(
-            'app', 'p4a.url', 'https://github.com/{}/python-for-android.git'.format(p4a_fork)
+            'app', 'p4a.url', f'https://github.com/{p4a_fork}/python-for-android.git'
         )
         p4a_branch = self.buildozer.config.getdefault(
             'app', 'p4a.branch', self.p4a_branch
@@ -722,9 +722,7 @@ class TargetAndroid(Target):
                 )[0].split()[1]
                 if any([cur_url != p4a_url, cur_branch != p4a_branch]):
                     self.buildozer.info(
-                        "Detected old url/branch ({}/{}), deleting...".format(
-                            cur_url, cur_branch
-                        )
+                        f"Detected old url/branch ({cur_url}/{cur_branch}), deleting..."
                     )
                     rmtree(p4a_dir)
 

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -53,7 +53,7 @@ def init_buildozer(temp_dir, target, options=None):
     spec = []
     for line in default_spec:
         if line.strip():
-            match = re.search(r"[#\s]?([a-z_\.]+)", line)
+            match = re.search(r"[#\s]?([0-9a-z_.]+)", line)
             key = match and match.group(1)
             if key in options:
                 line = "{} = {}\n".format(key, options[key])


### PR DESCRIPTION
Currently it's not possible to set own p4a mirror (not a fork on GitHub) in buildozer.spec.
This possibility already exists for kivy_ios, but not for p4a.

This PR allows to setting custom URL for p4a in the spec, instead of simply specifying fork.

The URL is used at first place. If no URL is specified, then fallback to github fork happens:
* p4a.url is set => URL is used;
* no p4a.url is set => https://github.com/{p4a.fork}/python-for-android.git is used;
* no p4a.url and no p4a.fork is set => default upstream (https://github.com/kivy/python-for-android.git) is used.

Backward compatibility with old specs is preserved with no behavioral changes.