### PR TITLE
Update iOS code signing

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -301,15 +301,39 @@ ios.ios_deploy_url = https://github.com/phonegap/ios-deploy
 ios.ios_deploy_branch = 1.10.0
 
 # (bool) Whether or not to sign the code
+# Sets `CODE_SIGNING_ALLOWED` xcodebuild option.
 ios.codesign.allowed = false
 
 # (str) Name of the certificate to use for signing the debug version
 # Get a list of available identities: buildozer ios list_identities
 #ios.codesign.debug = "iPhone Developer: <lastname> <firstname> (<hexstring>)"
 
+# (str) The code signing style for the debug version: Automatic or Manual.
+# Sets `CODE_SIGN_STYLE` xcodebuild option. Omitted if not specified.
+#ios.codesign.style.debug =
+
+# (str) Name of the development team to use for signing the debug version
+# Sets `DEVELOPMENT_TEAM` xcodebuild option. Omitted if not specified.
+#ios.codesign.development_team.debug =
+
+# (str) Name of the provisioning profile to use for manual signing of the debug version
+# Sets `PROVISIONING_PROFILE_SPECIFIER` xcodebuild option. Omitted if not specified.
+#ios.codesign.provisioning_profile.debug =
+
 # (str) Name of the certificate to use for signing the release version
 #ios.codesign.release = %(ios.codesign.debug)s
 
+# (str) The code signing style for the release version: Automatic or Manual
+# Sets `CODE_SIGN_STYLE` xcodebuild option. Omitted if not specified.
+#ios.codesign.style.release =
+
+# (str) Name of the development team to use for signing the release version
+# Sets `DEVELOPMENT_TEAM` xcodebuild option. Omitted if not specified.
+#ios.codesign.development_team.release =
+
+# (str) Name of the provisioning profile to use for manual signing of the release version
+# Sets `PROVISIONING_PROFILE_SPECIFIER` xcodebuild option. Omitted if not specified.
+#ios.codesign.provisioning_profile.release =
 
 [buildozer]
 

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -335,6 +335,18 @@ ios.codesign.allowed = false
 # Sets `PROVISIONING_PROFILE_SPECIFIER` xcodebuild option. Omitted if not specified.
 #ios.codesign.provisioning_profile.release =
 
+# (str) URL pointing to .ipa file to be installed
+# This option should be defined along with `display_image_url` and `full_size_image_url` options.
+#ios.manifest.app_url =
+
+# (str) URL pointing to an icon (57x57px) to be displayed during download
+# This option should be defined along with `app_url` and `full_size_image_url` options.
+#ios.manifest.display_image_url =
+
+# (str) URL pointing to a large icon (512x512px) to be used by iTunes
+# This option should be defined along with `app_url` and `display_image_url` options.
+#ios.manifest.full_size_image_url =
+
 [buildozer]
 
 # (int) Log level (0 = error only, 1 = info, 2 = debug (with command output))

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -274,14 +274,13 @@ class TargetIos(Target):
             cwd=build_dir)
 
         self.buildozer.info('Creating IPA...')
-        self.xcodebuild((
-                ' -exportArchive'
-                ' -exportFormat IPA'
-                ' -archivePath "{xcarchive}"'
-                ' -exportPath "{ipa}"'
-                ' CODE_SIGN_IDENTITY={ioscodesign}'
-                ' ENABLE_BITCODE=NO'
-            ).format(xcarchive=xcarchive, ipa=ipa_tmp, ioscodesign=ioscodesign),
+        self.xcodebuild(
+            '-exportArchive',
+            f'-archivePath "{xcarchive}"',
+            f'-exportOptionsPlist "{plist_rfn}"',
+            f'-exportPath "{ipa_tmp}"',
+            f'CODE_SIGN_IDENTITY={ioscodesign}'
+            'ENABLE_BITCODE=NO',
             cwd=build_dir)
 
         self.buildozer.info('Moving IPA to bin...')

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -226,6 +226,24 @@ class TargetIos(Target):
         # add icons
         self._create_icons()
 
+        # Generate OTA distribution manifest if `app_url`, `display_image_url` and `full_size_image_url` are defined.
+        app_url = self.buildozer.config.getdefault("app", "ios.manifest.app_url", None)
+        display_image_url = self.buildozer.config.getdefault("app", "ios.manifest.display_image_url", None)
+        full_size_image_url = self.buildozer.config.getdefault("app", "ios.manifest.full_size_image_url", None)
+
+        if any((app_url, display_image_url, full_size_image_url)):
+
+            if not all((app_url, display_image_url, full_size_image_url)):
+                self.buildozer.error("Options ios.manifest.app_url, ios.manifest.display_image_url"
+                                     " and ios.manifest.full_size_image_url should be defined")
+                return
+
+            plist['manifest'] = {
+                'appURL': app_url,
+                'displayImageURL': display_image_url,
+                'fullSizeImageURL': full_size_image_url,
+            }
+
         # ok, write the modified plist.
         plistlib.writePlist(plist, plist_rfn)
 

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -182,7 +182,6 @@ class TestTargetIos:
         # fmt: off
         with patch_target_ios("_unlock_keychain") as m_unlock_keychain, \
              patch_buildozer_error() as m_error, \
-             patch_target_ios("xcodebuild") as m_xcodebuild, \
              mock.patch("buildozer.targets.ios.plistlib.readPlist") as m_readplist, \
              mock.patch("buildozer.targets.ios.plistlib.writePlist") as m_writeplist, \
              patch_buildozer_cmd() as m_cmd:
@@ -194,13 +193,6 @@ class TestTargetIos:
             mock.call(
                 "Cannot create the IPA package without signature. "
                 'You must fill the "ios.codesign.debug" token.'
-            )
-        ]
-        assert m_xcodebuild.call_args_list == [
-            mock.call(
-                "-configuration Debug ENABLE_BITCODE=NO "
-                "CODE_SIGNING_ALLOWED=NO clean build",
-                cwd="/ios/dir/myapp-ios",
             )
         ]
         assert m_readplist.call_args_list == [
@@ -216,4 +208,8 @@ class TestTargetIos:
                 "/ios/dir/myapp-ios/myapp-Info.plist",
             )
         ]
-        assert m_cmd.call_args_list == [mock.call(mock.ANY, cwd=target.ios_dir)]
+        assert m_cmd.call_args_list == [mock.call(mock.ANY, cwd=target.ios_dir), mock.call(
+            "xcodebuild -configuration Debug ENABLE_BITCODE=NO "
+            "CODE_SIGNING_ALLOWED=NO clean build",
+            cwd="/ios/dir/myapp-ios",
+        )]


### PR DESCRIPTION
During testing of IPA build & sign couple of points for improvement where identified.

1. Commit "Add iOS options for manual code signing" adds some flexibility for automated builds in specifying code signing options like the development team and the provisioning profile to use for signing. The change is backward-compatible with old specs: if those parameters are not set, they are omitted from xcodebuild command invocation.
2. Commit "Update xcodebuild exportArchive options" removes exportFormat parameter of the exportArchive, which was [removed in Xcode 8.3](https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW162) and adds exportOptionsPlist parameter instead.
3. Commit "iOS OTA manifest generation for in-house distribution" enables generation of manifest.plist to be used for in-house OTA ipa distribution.