### PR TITLE
Update iOS codesign options

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -307,8 +307,14 @@ ios.codesign.allowed = false
 # Get a list of available identities: buildozer ios list_identities
 #ios.codesign.debug = "iPhone Developer: <lastname> <firstname> (<hexstring>)"
 
+# (str) The development team to use for signing the debug version
+#ios.codesign.development_team.debug = <hexstring>
+
 # (str) Name of the certificate to use for signing the release version
 #ios.codesign.release = %(ios.codesign.debug)s
+
+# (str) The development team to use for signing the release version
+#ios.codesign.development_team.release = <hexstring>
 
 
 [buildozer]

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -115,14 +115,19 @@ class TargetIos(Target):
         kwargs.setdefault('cwd', self.ios_dir)
         return self.buildozer.cmd(self._toolchain_cmd + cmd, **kwargs)
 
-    def xcodebuild(self, cmd='', **kwargs):
-        return self.buildozer.cmd(self._xcodebuild_cmd + cmd, **kwargs)
+    def xcodebuild(self, *args, **kwargs):
+        return self.buildozer.cmd(self._xcodebuild_cmd + ' '.join(arg for arg in args if arg is not None), **kwargs)
 
     @property
     def code_signing_allowed(self):
         allowed = self.buildozer.config.getboolean("app", "ios.codesign.allowed")
         allowed = "YES" if allowed else "NO"
         return f"CODE_SIGNING_ALLOWED={allowed}"
+
+    @property
+    def code_signing_development_team(self):
+        team = self.buildozer.config.getdefault("app", f"ios.codesign.development_team.{self.build_mode}", None)
+        return f"DEVELOPMENT_TEAM={team}" if team else None
 
     def get_available_packages(self):
         available_modules = self.toolchain("recipes --compact", get_stdout=True)[0]
@@ -216,7 +221,12 @@ class TargetIos(Target):
 
         mode = self.build_mode.capitalize()
         self.xcodebuild(
-            f"-configuration {mode} ENABLE_BITCODE=NO {self.code_signing_allowed} clean build",
+            f'-configuration {mode}',
+            '-allowProvisioningUpdates',
+            'ENABLE_BITCODE=NO',
+            self.code_signing_allowed,
+            self.code_signing_development_team,
+            'clean build',
             cwd=self.app_project_dir)
         ios_app_dir = '{app_lower}-ios/build/{mode}-iphoneos/{app_lower}.app'.format(
                 app_lower=app_name.lower(), mode=mode)
@@ -242,25 +252,24 @@ class TargetIos(Target):
         self.buildozer.rmdir(intermediate_dir)
 
         self.buildozer.info('Creating archive...')
-        self.xcodebuild((
-                ' -alltargets'
-                ' -configuration {mode}'
-                ' -scheme {scheme}'
-                ' -archivePath "{xcarchive}"'
-                ' archive'
-                ' ENABLE_BITCODE=NO'
-            ).format(mode=mode, xcarchive=xcarchive, scheme=app_name.lower()),
+        self.xcodebuild(
+            '-alltargets',
+            f'-configuration {mode}',
+            f'-scheme {app_name.lower()}',
+            f'-archivePath "{xcarchive}"',
+            'archive',
+            'ENABLE_BITCODE=NO',
+            self.code_signing_development_team,
             cwd=build_dir)
 
         self.buildozer.info('Creating IPA...')
-        self.xcodebuild((
-                ' -exportArchive'
-                ' -exportFormat IPA'
-                ' -archivePath "{xcarchive}"'
-                ' -exportPath "{ipa}"'
-                ' CODE_SIGN_IDENTITY={ioscodesign}'
-                ' ENABLE_BITCODE=NO'
-            ).format(xcarchive=xcarchive, ipa=ipa_tmp, ioscodesign=ioscodesign),
+        self.xcodebuild(
+            '-exportArchive',
+            f'-archivePath "{xcarchive}"',
+            f'-exportOptionsPlist "{plist_rfn}"',
+            f'-exportPath "{ipa_tmp}"',
+            f'CODE_SIGN_IDENTITY={ioscodesign}',
+            'ENABLE_BITCODE=NO',
             cwd=build_dir)
 
         self.buildozer.info('Moving IPA to bin...')

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -182,7 +182,6 @@ class TestTargetIos:
         # fmt: off
         with patch_target_ios("_unlock_keychain") as m_unlock_keychain, \
              patch_buildozer_error() as m_error, \
-             patch_target_ios("xcodebuild") as m_xcodebuild, \
              mock.patch("buildozer.targets.ios.plistlib.readPlist") as m_readplist, \
              mock.patch("buildozer.targets.ios.plistlib.writePlist") as m_writeplist, \
              patch_buildozer_cmd() as m_cmd:
@@ -194,13 +193,6 @@ class TestTargetIos:
             mock.call(
                 "Cannot create the IPA package without signature. "
                 'You must fill the "ios.codesign.debug" token.'
-            )
-        ]
-        assert m_xcodebuild.call_args_list == [
-            mock.call(
-                "-configuration Debug ENABLE_BITCODE=NO "
-                "CODE_SIGNING_ALLOWED=NO clean build",
-                cwd="/ios/dir/myapp-ios",
             )
         ]
         assert m_readplist.call_args_list == [
@@ -216,4 +208,8 @@ class TestTargetIos:
                 "/ios/dir/myapp-ios/myapp-Info.plist",
             )
         ]
-        assert m_cmd.call_args_list == [mock.call(mock.ANY, cwd=target.ios_dir)]
+        assert m_cmd.call_args_list == [mock.call(mock.ANY, cwd=target.ios_dir), mock.call(
+            "xcodebuild -configuration Debug -allowProvisioningUpdates ENABLE_BITCODE=NO "
+            "CODE_SIGNING_ALLOWED=NO clean build",
+            cwd="/ios/dir/myapp-ios",
+        )]


### PR DESCRIPTION
During testing of iOS codesign a few issues were found:
- missing ability to specify development team, which is required;
- missing allowProvisioningUpdates option;
- exportFormat option was still used, despite the fact that it was removed in Xcode 8.3.

This PR addresses these issues.

As a result, I was able to get properly signed IPA:
```
Exported testapp to: /Users/jenkins/Jenkins/workspace/testapp/ios-debug/.buildozer/ios/platform/kivy-ios/testapp-0.1.7.intermediates/testapp-0.1.7.ipa
** EXPORT SUCCEEDED **

# Moving IPA to bin...
# Rename /Users/jenkins/Jenkins/workspace/testapp/ios-debug/.buildozer/ios/platform/kivy-ios/testapp-0.1.7.intermediates/testapp-0.1.7.ipa to /Users/jenkins/Jenkins/workspace/testapp/ios-debug/bin/testapp-0.1.7.ipa
# iOS packaging done!
# IPA testapp-0.1.7.ipa available in the bin directory
```