### PR TITLE
android: adaptive icon/launcher: expose p4a options in buildozer.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -87,6 +87,10 @@ fullscreen = 0
 # Lottie files can be created using various tools, like Adobe After Effect or Synfig.
 #android.presplash_lottie = "path/to/lottie/file.json"
 
+# (str) Adaptive icon of the application (used if Android API level is 26+ at runtime)
+#icon.adaptive_foreground.filename = %(source.dir)s/data/icon_fg.png
+#icon.adaptive_background.filename = %(source.dir)s/data/icon_bg.png
+
 # (list) Permissions
 #android.permissions = INTERNET
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1134,6 +1134,11 @@ class TargetAndroid(Target):
         icon = config.getdefault('app', 'icon.filename', '')
         if icon:
             build_cmd += [("--icon", join(self.buildozer.root_dir, icon))]
+        icon_fg = config.getdefault('app', 'icon.adaptive_foreground.filename', '')
+        icon_bg = config.getdefault('app', 'icon.adaptive_background.filename', '')
+        if icon_fg and icon_bg:
+            build_cmd += [("--icon-fg", join(self.buildozer.root_dir, icon_fg))]
+            build_cmd += [("--icon-bg", join(self.buildozer.root_dir, icon_bg))]
 
         # OUYA Console support
         ouya_category = config.getdefault('app', 'android.ouya.category',


### PR DESCRIPTION
see related p4a PR: https://github.com/kivy/python-for-android/pull/2446

This exposes the p4a options added in the referenced PR in `buildozer.spec`.