### PR TITLE
iOS OTA manifest generation for in-house app distribution

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -316,6 +316,18 @@ ios.codesign.allowed = false
 # (str) The development team to use for signing the release version
 #ios.codesign.development_team.release = <hexstring>
 
+# (str) URL pointing to .ipa file to be installed
+# This option should be defined along with `display_image_url` and `full_size_image_url` options.
+#ios.manifest.app_url =
+
+# (str) URL pointing to an icon (57x57px) to be displayed during download
+# This option should be defined along with `app_url` and `full_size_image_url` options.
+#ios.manifest.display_image_url =
+
+# (str) URL pointing to a large icon (512x512px) to be used by iTunes
+# This option should be defined along with `app_url` and `display_image_url` options.
+#ios.manifest.full_size_image_url =
+
 
 [buildozer]
 

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -216,6 +216,24 @@ class TargetIos(Target):
         # add icons
         self._create_icons()
 
+        # Generate OTA distribution manifest if `app_url`, `display_image_url` and `full_size_image_url` are defined.
+        app_url = self.buildozer.config.getdefault("app", "ios.manifest.app_url", None)
+        display_image_url = self.buildozer.config.getdefault("app", "ios.manifest.display_image_url", None)
+        full_size_image_url = self.buildozer.config.getdefault("app", "ios.manifest.full_size_image_url", None)
+
+        if any((app_url, display_image_url, full_size_image_url)):
+
+            if not all((app_url, display_image_url, full_size_image_url)):
+                self.buildozer.error("Options ios.manifest.app_url, ios.manifest.display_image_url"
+                                     " and ios.manifest.full_size_image_url should be defined all together")
+                return
+
+            plist['manifest'] = {
+                'appURL': app_url,
+                'displayImageURL': display_image_url,
+                'fullSizeImageURL': full_size_image_url,
+            }
+
         # ok, write the modified plist.
         plistlib.writePlist(plist, plist_rfn)
 


### PR DESCRIPTION
This PR enables `manifest.plist` iOS generation, which can be used for installing the IPA via Safari.


