### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -234,7 +234,7 @@ class Target:
 
         This will clone the contents of a git repository to
         `buildozer.platform_dir`. The location of this repo can be
-        speficied via URL and branch name, or via a custom (local)
+        specified via URL and branch name, or via a custom (local)
         directory name.
 
         :Parameters:

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -120,7 +120,7 @@ class TargetAndroid(Target):
         # Default p4a dir
         p4a_dir = join(self.buildozer.platform_dir, self.p4a_directory_name)
 
-        # Possibly overriden by user setting
+        # Possibly overridden by user setting
         system_p4a_dir = self.buildozer.config.getdefault('app', 'p4a.source_dir')
         if system_p4a_dir:
             p4a_dir = expanduser(system_p4a_dir)

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -61,7 +61,7 @@ class TestBuildozer(unittest.TestCase):
 
     def test_buildozer_base(self):
         """
-        Basic test making sure the Buildozer object can be instanciated.
+        Basic test making sure the Buildozer object can be instantiated.
         """
         buildozer = Buildozer()
         assert buildozer.specfilename == 'buildozer.spec'


### PR DESCRIPTION
There are small typos in:
- buildozer/target.py
- buildozer/targets/android.py
- tests/test_buildozer.py

Fixes:
- Should read `specified` rather than `speficied`.
- Should read `overridden` rather than `overriden`.
- Should read `instantiated` rather than `instanciated`.

Closes #1326