### PR TITLE
Android: Expose support for native services in buildozer

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -191,6 +191,9 @@ fullscreen = 0
 # (list) Java classes to add as activities to the manifest.
 #android.add_activities = com.example.ExampleActivity
 
+# (list) List of native services to declare
+#android.native_services = org.kivy.example.MyNativeService
+
 # (str) OUYA Console category. Should be one of GAME or APP
 # If you leave this blank, OUYA support will not be enabled
 #android.ouya.category = GAME

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -859,6 +859,12 @@ class TargetAndroid(Target):
             cmd.append("--service")
             cmd.append(service)
 
+        # support for native-service
+        nativeservices = self.buildozer.config.getlist('app', 'android.native_services', [])
+        for nativeservice in nativeservices:
+            cmd.append("--native-service")
+            cmd.append(nativeservice)
+
         # support for copy-libs
         if self.buildozer.config.getbooldefault('app', 'android.copy_libs', True):
             cmd.append("--copy-libs")


### PR DESCRIPTION
This PR exposes support for native services in buildozer.
(see https://github.com/kivy/python-for-android/pull/2244)