### PR TITLE
add the option p4a.extra_args

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -313,6 +313,9 @@ android.allow_backup = True
 # setup.py if you're using Poetry, but you need to add "toml" to source.include_exts.
 #p4a.setup_py = false
 
+# (str) extra command line arguments to pass when invoking pythonforandroid.toolchain
+#p4a.extra_args =
+
 
 #
 # iOS specific

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -108,6 +108,11 @@ class TargetAndroid(Target):
         if self.buildozer.log_level >= 2:
             self.extra_p4a_args += ' --debug'
 
+        user_extra_p4a_args = self.buildozer.config.getdefault('app', 'p4a.extra_args',
+                                                               None)
+        if user_extra_p4a_args:
+            self.extra_p4a_args += ' ' + user_extra_p4a_args
+
         self.warn_on_deprecated_tokens()
 
     def warn_on_deprecated_tokens(self):


### PR DESCRIPTION
This option allows to pass arbitrary arguments to p4a.
It is useful especially when using experimental versions and/or forks introducing new options for which buildozer doesn't have a "first class option" yet.

In the following example I used it to use the new experimental `--fileprovider-paths`:
https://github.com/antocuni/plyer_camera_example
https://github.com/antocuni/plyer_camera_example/blob/e820f2bd70795e7c829329135967f751c5ddc706/src/buildozer.spec#L47-L52