### PR TITLE
Add android.add_assets

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -180,8 +180,8 @@ fullscreen = 0
 # (list) Android AAR archives to add
 #android.add_aars =
 
-# (list) Put these files or directories in the apk assets directory
-# Usage: ( file extensions must be in 'source.include_exts' )
+# (list) Put these files or directories in the apk assets directory.
+# Either form may be used, and assets need not be in 'source.include_exts'.
 # 1) android.add_assets = source_asset_relative_path
 # 2) android.add_assets = source_asset_path:destination_asset_relative_path
 #android.add_assets =

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -25,6 +25,7 @@ source.include_exts = py,png,jpg,kv,atlas
 #source.exclude_dirs = tests, bin, venv
 
 # (list) List of exclusions using pattern matching
+# Do not prefix with './'
 #source.exclude_patterns = license,images/*/*.jpg
 
 # (str) Application versioning (method 1)
@@ -180,9 +181,9 @@ fullscreen = 0
 #android.add_aars =
 
 # (list) Put these files or directories in the apk assets directory
-# Two forms, do not use an absolute path, including '~/' in the first form.
+# Usage: (file extensions must be in 'source.include_exts')
 # 1) android.add_assets = source_asset_relative_path
-# 2) android.add_assets = source_asset_path:destination_asset_path
+# 2) android.add_assets = source_asset_path:destination_asset_relative_path
 #android.add_assets =
 
 # (list) Gradle dependencies to add

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -181,7 +181,7 @@ fullscreen = 0
 #android.add_aars =
 
 # (list) Put these files or directories in the apk assets directory
-# Usage: (file extensions must be in 'source.include_exts')
+# Usage: ( file extensions must be in 'source.include_exts' )
 # 1) android.add_assets = source_asset_relative_path
 # 2) android.add_assets = source_asset_path:destination_asset_relative_path
 #android.add_assets =

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -179,6 +179,12 @@ fullscreen = 0
 # (list) Android AAR archives to add
 #android.add_aars =
 
+# (list) Put these files or directories in the apk assets directory
+# Two forms, do not use an absolute path, including '~/' in the first form.
+# 1) android.add_assets = source_asset_relative_path
+# 2) android.add_assets = source_asset_path:destination_asset_path
+#android.add_assets =
+
 # (list) Gradle dependencies to add
 #android.gradle_dependencies =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -909,7 +909,7 @@ class TargetAndroid(Target):
             cmd.append('--add-asset')
             if ':' in asset:
                 asset_src, asset_dest = asset.split(":")
-            else asset_dest:
+            else:
                 asset_src = asset
                 asset_dest = asset
             cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -907,9 +907,11 @@ class TargetAndroid(Target):
         assets = self.buildozer.config.getlist('app', 'android.add_assets', [])
         for asset in assets:
             cmd.append('--add-asset')
-            asset_src, asset_dest = asset.split(":")
-            if not asset_dest:
-                asset_dest = asset_src
+            if ':' in asset:
+                asset_src, asset_dest = asset.split(":")
+            else asset_dest:
+                asset_src = asset
+                asset_dest = asset
             cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)
 
         # support for uses-lib

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -903,6 +903,12 @@ class TargetAndroid(Target):
             cmd.append('--add-aar')
             cmd.append(realpath(expanduser(aar)))
 
+        # support for assets folder
+        assets = self.buildozer.config.getlist('app', 'android.add_assets', [])
+        for asset in assets:
+            cmd.append('--add-asset')
+            cmd.append(asset)
+
         # support for uses-lib
         uses_library = self.buildozer.config.getlist(
             'app', 'android.uses_library', '')

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -907,7 +907,10 @@ class TargetAndroid(Target):
         assets = self.buildozer.config.getlist('app', 'android.add_assets', [])
         for asset in assets:
             cmd.append('--add-asset')
-            cmd.append(asset)
+            asset_src, asset_dest = asset.split(":")
+            if not asset_dest:
+                asset_dest = asset_src
+            cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)
 
         # support for uses-lib
         uses_library = self.buildozer.config.getlist(

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -911,7 +911,6 @@ class TargetAndroid(Target):
             if not asset_dest:
                 asset_dest = asset_src
             cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)
-            
 
         # support for uses-lib
         uses_library = self.buildozer.config.getlist(

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -912,7 +912,7 @@ class TargetAndroid(Target):
             else:
                 asset_src = asset
                 asset_dest = asset
-            cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)
+            cmd.append(realpath(expanduser(asset_src)) + ':' + asset_dest)
 
         # support for uses-lib
         uses_library = self.buildozer.config.getlist(

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -911,6 +911,7 @@ class TargetAndroid(Target):
             if not asset_dest:
                 asset_dest = asset_src
             cmd.append(realpath(expanduser(asset_src))+':'+asset_dest)
+            
 
         # support for uses-lib
         uses_library = self.buildozer.config.getlist(


### PR DESCRIPTION
1) Add `android.add_assets` command, a front end for p4a's existing `--add-asset` command.

Required for newer Android Tensorflow Lite Java modules that require the `.tflite` file to be in the assets directory. 

2) Add a comment to #source.exclude_patterns to clarify a common user issue. 