### PR TITLE
iOS: force archive iOS destination

### DIFF
--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -283,6 +283,7 @@ class TargetIos(Target):
             f'-configuration {mode}',
             f'-scheme {app_name.lower()}',
             f'-archivePath "{xcarchive}"',
+            '-destination \'generic/platform=iOS\'',
             'archive',
             'ENABLE_BITCODE=NO',
             self.code_signing_development_team,


### PR DESCRIPTION
Without destination being set, archive command fails on a M1 Mac:

```
# Creating archive...
# Run 'xcodebuild -alltargets -configuration Debug -scheme app -archivePath ".../.buildozer/ios/platform/kivy-ios/app-0.0.1.intermediates/app-0.0.1.xcarchive" archive ENABLE_BITCODE=NO DEVELOPMENT_TEAM=...'
# Cwd .../.buildozer/ios/platform/kivy-ios/app-ios
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -alltargets -configuration Debug -scheme app -archivePath .../.buildozer/ios/platform/kivy-ios/app-0.0.1.intermediates/app-0.0.1.xcarchive archive ENABLE_BITCODE=NO DEVELOPMENT_TEAM=...

User defaults from command line:
    IDEArchivePathOverride = .../.buildozer/ios/platform/kivy-ios/app-0.0.1.intermediates/app-0.0.1.xcarchive
    IDEPackageSupportUseBuiltinSCM = YES

Build settings from command line:
    DEVELOPMENT_TEAM = ...
    ENABLE_BITCODE = NO

--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:... }
{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
...
note: Using new build system
note: Planning
Analyze workspace

Create build description
Build description signature: ...
Build description path: .../XCBuildData/d7301a4741f170119807e5d6d2248f00-desc.xcbuild

note: Build preparation complete
note: Building targets in dependency order
error: Provisioning profile "iOS Team Provisioning Profile: ..." doesn't include the currently selected device "mac-m1-mini’s Mac mini" (identifier ...). (in target 'app' from project 'app')
** ARCHIVE FAILED **
```
