### PR TITLE
Improves iOS CI workflow and adds Apple Silicon M1 runner

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e -x
+
+arm64_set_path_and_python_version(){
+  python_version="$1"
+  if [[ $(/usr/bin/arch) = arm64 ]]; then
+      export PATH=/opt/homebrew/bin:$PATH
+      eval "$(pyenv init --path)"
+      pyenv install $python_version -s
+      pyenv global $python_version
+      export PATH=$(pyenv prefix)/bin:$PATH
+  fi
+}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,23 +2,51 @@ on: [push, pull_request]
 name: iOS
 jobs:
   Integration:
-    runs-on: macOS-latest
+    name: "Integration (${{ matrix.runs_on }}, ${{ matrix.python }})"
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on || 'macos-latest' }}
+    strategy:
+      matrix:
+        include:
+          - runs_on: macos-latest
+            python: '3.9'
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+            python: '3.9.7'
     steps:
     - name: Setup python
+      # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+      if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
     - uses: actions/checkout@v2
     - name: Setup environment
       run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
         pip install -e .
         pip install Cython cookiecutter pbxproj
-    - run: buildozer --help
-    - run: buildozer init
+    - name: Check buildozer installation
+      run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        buildozer --help
+    - name: Initialize buildozer in project folder
+      run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        buildozer init
     - name: Install dependencies
       run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
         brew install autoconf automake libtool pkg-config
     - name: buildozer ios debug
       run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
         touch main.py
         buildozer ios debug

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -258,15 +258,6 @@ class TargetIos(Target):
                 app_lower=app_name.lower(), mode=mode)
         self.buildozer.state['ios:latestappdir'] = ios_app_dir
 
-        key = 'ios.codesign.{}'.format(self.build_mode)
-        ioscodesign = self.buildozer.config.getdefault('app', key, '')
-        if not ioscodesign:
-            self.buildozer.error('Cannot create the IPA package without'
-                ' signature. You must fill the "{}" token.'.format(key))
-            return
-        elif ioscodesign[0] not in ('"', "'"):
-            ioscodesign = '"{}"'.format(ioscodesign)
-
         intermediate_dir = join(self.ios_dir, '{}-{}.intermediates'.format(app_name, version))
         xcarchive = join(intermediate_dir, '{}-{}.xcarchive'.format(
             app_name, version))
@@ -286,8 +277,18 @@ class TargetIos(Target):
             '-destination \'generic/platform=iOS\'',
             'archive',
             'ENABLE_BITCODE=NO',
+            self.code_signing_allowed,
             self.code_signing_development_team,
             cwd=build_dir)
+
+        key = 'ios.codesign.{}'.format(self.build_mode)
+        ioscodesign = self.buildozer.config.getdefault('app', key, '')
+        if not ioscodesign:
+            self.buildozer.error('Cannot create the IPA package without'
+                ' signature. You must fill the "{}" token.'.format(key))
+            return
+        elif ioscodesign[0] not in ('"', "'"):
+            ioscodesign = '"{}"'.format(ioscodesign)
 
         self.buildozer.info('Creating IPA...')
         self.xcodebuild(

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -176,7 +176,7 @@ class TestTargetIos:
         ]
 
     def test_build_package_no_signature(self):
-        """Code signing is currently required to go through final `xcodebuild` steps."""
+        """Code signing is currently required to go through final `xcodebuild` step."""
         target = init_target(self.temp_dir)
         target.ios_dir = "/ios/dir"
         # fmt: off
@@ -208,8 +208,18 @@ class TestTargetIos:
                 "/ios/dir/myapp-ios/myapp-Info.plist",
             )
         ]
-        assert m_cmd.call_args_list == [mock.call(mock.ANY, cwd=target.ios_dir), mock.call(
-            "xcodebuild -configuration Debug -allowProvisioningUpdates ENABLE_BITCODE=NO "
-            "CODE_SIGNING_ALLOWED=NO clean build",
-            cwd="/ios/dir/myapp-ios",
-        )]
+        assert m_cmd.call_args_list == [
+            mock.call(mock.ANY, cwd=target.ios_dir),
+            mock.call(
+                "xcodebuild -configuration Debug -allowProvisioningUpdates ENABLE_BITCODE=NO "
+                "CODE_SIGNING_ALLOWED=NO clean build",
+                cwd="/ios/dir/myapp-ios",
+            ),
+            mock.call(
+                "xcodebuild -alltargets -configuration Debug -scheme myapp "
+                "-archivePath \"/ios/dir/myapp-0.1.intermediates/myapp-0.1.xcarchive\" "
+                "-destination \'generic/platform=iOS\' "
+                "archive ENABLE_BITCODE=NO CODE_SIGNING_ALLOWED=NO",
+                cwd="/ios/dir/myapp-ios",
+            ),
+        ]


### PR DESCRIPTION
This PR improves CI workflow and adds our Apple Silicon M1 runner in matrix, so we can test changes also on Apple Silicon.
Unfortunately, unless we configure a keychain with Provisioning and Development profiles, we're unable to discover issues like the one that has been fixed via #1392 