### PR TITLE
Update installation.rst

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,7 +22,7 @@ Android on Ubuntu 20.04 (64bit)
 ::
 
     sudo apt update
-    sudo apt install -y git zip unzip openjdk-13-jdk python3-pip autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev
+    sudo apt install -y git zip unzip openjdk-8-jdk python3-pip autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev
     pip3 install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
 
     # add the following line at the end of your ~/.bashrc file


### PR DESCRIPTION
changed "openjdk-13-jdk" to "openjdk-8-jdk", because "openjdk-13-jdk" isn't availible in Ubuntu 21.10.