### PR TITLE
[WIP] Adds an option to allow add resources to Android res/ directory

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -186,21 +186,19 @@ fullscreen = 0
 # 2) android.add_assets = source_asset_path:destination_asset_relative_path
 #android.add_assets =
 
-# Copy/overwrite directories and its files (from within the "user_res" directory, as in the example below)
-# in the android res directory in res/
+# Copy/overwrite directories and its files in the android res directory in res/
+# from within the "android_resources" directory, as in the example below.
 # Example, create:
-# user_res/
+# android_resources/
 #     drawable/
 #         graphic.png
 #     anim/
 #         anim.xml
 #     xml/
 #         strings.xml
-# And then, you must pass the "user_res" directory path to the add_res argument
-# The default p4a res directories are: "values", "layout", "mipmap", "mipmap-anydpi-v26",
-# "drawable", "drawable-mdpi", "drawable-hdpi", "drawable-xhdpi", " drawable-xxhdpi"
-# See https://developer.android.com/guide/topics/resources/providing-resources
-#android.add_res = "path/to/user_res/folder"
+# And then, you must pass the "android_resources" directory path to the add_res argument
+# For general documentation see https://developer.android.com/guide/topics/resources/providing-resources
+# android.add_res = "path/to/android_resources"
 
 # (list) Gradle dependencies to add
 #android.gradle_dependencies =

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -186,6 +186,22 @@ fullscreen = 0
 # 2) android.add_assets = source_asset_path:destination_asset_relative_path
 #android.add_assets =
 
+# Copy/overwrite directories and its files (from within the "user_res" directory, as in the example below)
+# in the android res directory in res/
+# Example, create:
+# user_res/
+#     drawable/
+#         graphic.png
+#     anim/
+#         anim.xml
+#     xml/
+#         strings.xml
+# And then, you must pass the "user_res" directory path to the add_res argument
+# The default p4a res directories are: "values", "layout", "mipmap", "mipmap-anydpi-v26",
+# "drawable", "drawable-mdpi", "drawable-hdpi", "drawable-xhdpi", " drawable-xxhdpi"
+# See https://developer.android.com/guide/topics/resources/providing-resources
+#android.add_res = "path/to/user_res/folder"
+
 # (list) Gradle dependencies to add
 #android.gradle_dependencies =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1179,6 +1179,11 @@ class TargetAndroid(Target):
             meta = '{}={}'.format(key.strip(), value.strip())
             build_cmd += [("--meta-data", meta)]
 
+        # add res
+        res = config.getdefault('app', 'android.add_res', '')
+        if res:
+            build_cmd += [("--add-res", join(self.buildozer.root_dir, res))]
+
         # add extra Java jar files
         add_jars = config.getlist('app', 'android.add_jars', [])
         for pattern in add_jars:


### PR DESCRIPTION
Depends on:
- kivy/python-for-android#2580

General explanations of feature need: #1397 
Reference: https://developer.android.com/guide/topics/resources/providing-resources

Using specific solutions will not be enough in the long term, so this PR is intended to provide a more comprehensive option for managing android resources.

With the main intention of facilitating the use of the resource and its management, the user will only need to create a folder with the structure below, and pass its path to the `android.add_res` argument.

```
res/
    drawable/
        graphic.png
    anim/
        anim.xml
    mipmap/
        img.png
    xml/
        value.xml
```

I believe it's important to reset the dist `res/` folder values to default directories and files before each copy/overwrite of user resource files, but I still haven't figured out how python-for-android do it.


PRs it can cover (at least partially) :
#1119 
#1230 
#1417

Maybe related issue: #167