### PR TITLE
Fix Docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A Dockerfile is available to use buildozer through a Docker environment.
 
 - Run with:
 
-      docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+      docker run -it --volume "$(pwd)":/home/user/hostcwd buildozer --version
 
 
 ## Buildozer GitHub action


### PR DESCRIPTION
When building using the Dockerfile, I wasn't able to accept the required licenses. Instead, they immediately got rejected. The build always ended with the following error:
```
Aidl not found, please install it. 
```
To fix this, all that was needed was to add `-it` options to the docker command on run. Thus, it is now able to take user input and the license can be accepted.
I hope I saved someone's struggles.