### PR TITLE
Updates default buildozer.spec NDK from 19b to 23b

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -108,7 +108,7 @@ fullscreen = 0
 #android.sdk = 20
 
 # (str) Android NDK version to use
-#android.ndk = 19b
+#android.ndk = 23b
 
 # (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
 #android.ndk_api = 21


### PR DESCRIPTION
Similar to #1041 

Note that this is only the template spec file and `DEFAULT_ANDROID_NDK_VERSION` fallback is left untouched.
