### PR TITLE
p4a prerequisites install should be done in non-interactive mode during CI builds.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,8 @@
 on: [push, pull_request]
+
+env:
+  PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE: 0
+
 name: Android
 jobs:
   Integration:


### PR DESCRIPTION
As `python-for-android` CI ([see](https://github.com/kivy/python-for-android/blob/b3e8c0378d65bd7f705b90fc915c4068b34d1b9a/.github/workflows/push.yml#L9)) , also the CI runs for Android in `buildozer` need to have `PYTHONFORANDROID_PREREQUISITES_INSTALL_INTERACTIVE` set to `0`.

This is needed as `python-for-android` now handles a prerequisites check + advice + install (on macOS, coming soon to other platforms), and expects input from the user.

⚠️ Working on docs, and that option will be included also on `buildozer` docs.