### PR TITLE
Removes `six` dependency in tests

### DIFF
--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from six import StringIO
+from io import StringIO
 from unittest import mock
 import sys
 

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -4,7 +4,7 @@ import codecs
 import unittest
 import buildozer as buildozer_module
 from buildozer import Buildozer
-from six import StringIO
+from io import StringIO
 import tempfile
 from unittest import mock
 


### PR DESCRIPTION
- We dropped `Python2` support here: https://github.com/kivy/buildozer/pull/1094
- `six` dependency was still required by tests, but not installed.
- Seems that GitHub removed `six` from the pre-installed Python packages in version `20220724` of the Ubuntu 20.04 virtual-environment, so the test started to fail just recently.