### PR TITLE
Show output during aab support check, as p4a may require the user input

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -320,7 +320,7 @@ class TargetAndroid(Target):
         super().check_configuration_tokens(errors)
 
     def _p4a_have_aab_support(self):
-        returncode = self._p4a(["aab", "-h"], break_on_error=False, show_output=False)[2]
+        returncode = self._p4a(["aab", "-h"], break_on_error=False)[2]
         if returncode == 0:
             return True
         else:


### PR DESCRIPTION
Targets issue #1493 

`python-for-android` may require input from the user (e.g. when a prerequisite is not met and should be installed)

💡 We may want to introduce an API that checks if a feature is available, to avoid mimicking a real call that requires that feature.