### PR TITLE
Fixes some E275 - assert is a keyword.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -159,7 +159,7 @@ class Buildozer:
     def prepare_for_build(self):
         '''Prepare the build.
         '''
-        assert(self.target is not None)
+        assert self.target is not None
         if hasattr(self.target, '_build_prepared'):
             return
 
@@ -190,8 +190,8 @@ class Buildozer:
 
         (:meth:`prepare_for_build` must have been call before.)
         '''
-        assert(self.target is not None)
-        assert(hasattr(self.target, '_build_prepared'))
+        assert self.target is not None
+        assert hasattr(self.target, '_build_prepared')
 
         if hasattr(self.target, '_build_done'):
             return


### PR DESCRIPTION
- Assert is a keyword and a space is needed + the parentheses are not needed.
- A recent change in pycodestyle (See: https://github.com/PyCQA/pycodestyle/pull/1063) introduced this check.
- CI runs started to fail this evening.