### PR TITLE
android sdk tools: adapt path to file hierarchy changes

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -244,7 +244,10 @@ class TargetAndroid(Target):
     @property
     def sdkmanager_path(self):
         sdkmanager_path = join(
-            self.android_sdk_dir, 'tools', 'bin', 'sdkmanager')
+            self.android_sdk_dir, 'cmdline-tools', 'bin', 'sdkmanager')
+        if not os.path.isfile(sdkmanager_path):
+            sdkmanager_path = join(
+                self.android_sdk_dir, 'tools', 'bin', 'sdkmanager')
         if not os.path.isfile(sdkmanager_path):
             raise BuildozerException(
                 ('sdkmanager path "{}" does not exist, sdkmanager is not'


### PR DESCRIPTION
Recent Android SDK tools, including e.g. ["8092744"](https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip) and ["8512546"](https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip), use a different path structure than e.g. ["6514223"](https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip).

E.g. `sdkmanager` in older sdk tools used to be located at
  `${ANDROID_SDK_HOME}/tools/bin/sdkmanager`
but now it is at
  `${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager`

Related:
https://github.com/kivy/python-for-android/issues/2540
https://github.com/kivy/python-for-android/pull/2593