### PR TITLE
dependencies: rm `virtualenv`, already using `python3 -m venv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apt update -qq > /dev/null \
     patch \
     pkg-config \
     python3-pip \
+    python3-venv \
     python3-setuptools \
     sudo \
     unzip \
@@ -76,6 +77,6 @@ WORKDIR ${WORK_DIR}
 COPY --chown=user:user . ${SRC_DIR}
 
 # installs buildozer and dependencies
-RUN pip3 install --user --upgrade Cython==0.29.19 wheel pip virtualenv ${SRC_DIR}
+RUN pip3 install --user --upgrade Cython==0.29.19 wheel pip ${SRC_DIR}
 
 ENTRYPOINT ["buildozer"]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,8 +22,8 @@ Android on Ubuntu 20.04 and 22.04 (64bit)
 ::
 
     sudo apt update
-    sudo apt install -y git zip unzip openjdk-17-jdk python3-pip autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev
-    pip3 install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
+    sudo apt install -y git zip unzip openjdk-17-jdk python3-pip python3-venv autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev
+    pip3 install --user --upgrade Cython==0.29.19  # the --user should be removed if you do this in a venv
 
     # add the following line at the end of your ~/.bashrc file
     export PATH=$PATH:~/.local/bin/
@@ -64,7 +64,7 @@ Android on macOS
     brew install openssl
     sudo ln -sfn /usr/local/opt/openssl /usr/local/ssl
     brew install pkg-config autoconf automake
-    python3 -m pip install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
+    python3 -m pip install --user --upgrade Cython==0.29.19  # the --user should be removed if you do this in a venv
 
     # add the following line at the end of your `~/.bashrc` file
     export PATH=$PATH:~/Library/Python/3.7/bin
@@ -110,8 +110,8 @@ Install homebrew (https://brew.sh)
     brew install pkg-config sdl2 sdl2_image sdl2_ttf sdl2_mixer gstreamer autoconf automake
 
 
-Install pip and virtualenv
+Install pip
 
 ::
 
-    python3 -m pip install --user --upgrade pip virtualenv kivy-ios
+    python3 -m pip install --user --upgrade pip kivy-ios

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         ],
     package_data={'buildozer': ['default.spec']},
     include_package_data=True,
-    install_requires=['pexpect', 'virtualenv', 'sh'],
+    install_requires=['pexpect', 'sh'],
     classifiers=[
         'Development Status :: 5 - Production/Stable', 
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR removes the `virtualenv` dependency from `setup.py`, as it looks redundant.

To be fair, I am not fully certain why setup.py was declaring `virtualenv` as needed, I think it's a historical remnant of python 2 days.

The min required python version is atm 3.6:
https://github.com/kivy/buildozer/blob/9503f5fd153f3f08e9160799fc04b23faf6aabeb/setup.py#L16 `venv` is part of the stdlib since python 3.3, and "is now recommended for creating virtual environments" since 3.5: https://docs.python.org/3/library/venv.html
Note that `venv` is a subset of `virtualenv`, but buildozer AFAICT is only using that subset.

Similar change in p4a:
https://github.com/kivy/python-for-android/pull/2152

I've tested building a large android project with only `venv` available and it worked.