### PR TITLE
CeDeROM add FreeBSD support 20221014.

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -474,7 +474,7 @@ class TargetAndroid(Target):
             else:
                 ext = 'zip'
             archive = 'android-ndk-r{0}-' + _platform + '{1}.' + ext
-            is_64 = (os.uname()[4] == 'x86_64')
+            is_64 = ('64' in os.uname()[4])
         else:
             raise SystemError('Unsupported platform: {}'.format(platform))
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -265,7 +265,7 @@ class TargetAndroid(Target):
                                 'adb.exe')
             self.javac_cmd = self._locate_java('javac.exe')
             self.keytool_cmd = self._locate_java('keytool.exe')
-        # darwin, linux
+        # darwin, linux, freebsd
         else:
             self.adb_executable = join(self.android_sdk_dir, 'platform-tools', 'adb')
             self.javac_cmd = self._locate_java('javac')
@@ -278,6 +278,11 @@ class TargetAndroid(Target):
                 raise BuildozerException(
                     'zlib headers must be installed, '
                     'run: sudo apt-get install zlib1g-dev')
+
+            # Override the OS which `sdkmanager` should download the packages for.
+            # This enables download and use of Linux binaries on FreeBSD.
+            if platform.startswith('freebsd'):
+                os.environ['REPO_OS_OVERRIDE'] = 'linux'
 
         # Adb arguments:
         adb_args = self.buildozer.config.getdefault(
@@ -413,7 +418,7 @@ class TargetAndroid(Target):
             archive = 'commandlinetools-win-{}_latest.zip'.format(DEFAULT_SDK_TAG)
         elif platform in ('darwin', ):
             archive = 'commandlinetools-mac-{}_latest.zip'.format(DEFAULT_SDK_TAG)
-        elif platform.startswith('linux'):
+        elif platform.startswith('linux') or platform.startswith('freebsd'):
             archive = 'commandlinetools-linux-{}_latest.zip'.format(DEFAULT_SDK_TAG)
         else:
             raise SystemError('Unsupported platform: {0}'.format(platform))
@@ -453,14 +458,15 @@ class TargetAndroid(Target):
 
         is_darwin = platform == 'darwin'
         is_linux = platform.startswith('linux')
+        is_freebsd = platform.startswith('freebsd')
 
         if platform in ('win32', 'cygwin'):
             # Checking of 32/64 bits at Windows from: https://stackoverflow.com/a/1405971/798575
             import struct
             archive = 'android-ndk-r{0}-windows-{1}.zip'
             is_64 = (8 * struct.calcsize("P") == 64)
-        elif is_darwin or is_linux:
-            _platform = 'linux' if is_linux else 'darwin'
+        elif is_darwin or is_linux or is_freebsd:
+            _platform = 'linux' if (is_linux or is_freebsd) else 'darwin'
             if self.android_ndk_version in ['10c', '10d', '10e']:
                 ext = 'bin'
             elif _version <= 10:


### PR DESCRIPTION
1. Initial FreeBSD support using Linux binaries.
* FreeBSD can emulate Linux ELF binaries [1].
* Use the same process for FreeBSD as for Linux.
* Add FreeBSD recognition in checks.

[1] https://docs.freebsd.org/en/articles/linux-emulation/

2. Fix 64-bit detection based on os.uname.
* Not every OS uses `x86_64` in `uname` (i.e. FreeBSD uses `amd64`).
* Every 64-bit OS will have 64 in `uname`.
* Alternatively `platform.architecture()[0]` will return `64bit`.
