### PR TITLE
Removed (broken) `--no-byte-compile-pyo` support and added support for `--no-byte-compile-python`

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -283,8 +283,8 @@ android.allow_backup = True
 # Usage example : android.manifest_placeholders = [myCustomUrl:\"org.kivy.customurl\"]
 # android.manifest_placeholders = [:]
 
-# (bool) disables the compilation of py to pyc/pyo files when packaging
-# android.no-compile-pyo = True
+# (bool) Skip byte compile for .py files
+# android.no-byte-compile-python = False
 
 # (str) The format used to package the app for release mode (aab or apk or aar).
 # android.release_artifact = aab

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -980,10 +980,10 @@ class TargetAndroid(Target):
             cmd.append('--manifest-placeholders')
             cmd.append("{}".format(manifest_placeholders))
 
-        # support disabling of compilation
-        compile_py = self.buildozer.config.getdefault('app', 'android.no-compile-pyo', None)
-        if compile_py:
-            cmd.append('--no-compile-pyo')
+        # support disabling of byte compile for .py files
+        no_byte_compile = self.buildozer.config.getdefault('app', 'android.no-byte-compile-python', False)
+        if no_byte_compile:
+            cmd.append('--no-byte-compile-python')
 
         for arch in self._archs:
             cmd.append('--arch')


### PR DESCRIPTION
Related to: https://github.com/kivy/python-for-android/pull/2693

>- **As of Python 3.5, the `.pyo` filename extension is no longer used and has been removed in favour of extension `.pyc`**
All the references to `pyo` has been removed. `--no-compile-pyo` build option has been removed in favor of `--no-byte-compile-python`, which doesn't refer to a specific filename extension.