### PR TITLE
Corrections (fixes) for

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -970,14 +970,15 @@ class TargetAndroid(Target):
         extra_manifest_xml = self.buildozer.config.getdefault(
             'app', 'android.extra_manifest_xml', '')
         if extra_manifest_xml:
-            cmd.append('--extra-manifest-xml="{}"'.format(open(extra_manifest_xml, 'rt').read()))
+            cmd.append('--extra-manifest-xml')
+            cmd.append('{}'.format(open(extra_manifest_xml, 'rt').read()))
 
         # support for extra-manifest-application-arguments
         extra_manifest_application_arguments = self.buildozer.config.getdefault(
             'app', 'android.extra_manifest_application_arguments', '')
         if extra_manifest_application_arguments:
-            args_body = open(extra_manifest_application_arguments, 'rt').read().replace('"', '\\"').replace('\n', ' ').replace('\t', ' ')
-            cmd.append('--extra-manifest-application-arguments="{}"'.format(args_body))
+            cmd.append('--extra-manifest-application-arguments')
+            cmd.append('{}'.format(open(extra_manifest_application_arguments, 'rt').read()))
 
         # support for gradle dependencies
         gradle_dependencies = self.buildozer.config.getlist('app', 'android.gradle_dependencies', [])


### PR DESCRIPTION
- extra-manifest-xml
- extra-nanifest-application-attributes

This	also refers to issue #1535

My build has now been tested against the newest p4a and buldozer versions (cloned buildozer/master and python-for-android/develop). It fails for extra-manifest-xml and also for extra-manifest-application-attributes.

Obviously the new version of p4a behaves differently regarding processing of double quotes in Android Manifest	templates. Needs the buildozer code 
to reflect that.
