### PR TITLE
Flake8 does not support inline comments for any of the keys. + Cleanup some ignored errors/warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,21 @@ commands = flake8 buildozer/ tests/
 
 [flake8]
 ignore =
-    E121, # continuation line under-indented for hanging indent
-    E122, # continuation line missing indentation or outdented
-    E126, # continuation line over-indented for hanging indent
-    E127, # continuation line over-indented for visual indent
-    E128, # continuation line under-indented for visual indent
-    E131, # continuation line unaligned for hanging indent
-    E402, # module level import not at top of file
-    E501, # line too long
-    E722, # do not use bare 'except'
-    W503, # line break before binary operator
-    W504 # line break after binary operator
+    # continuation line missing indentation or outdented
+    E122,
+    # continuation line over-indented for hanging indent
+    E126,
+    # continuation line over-indented for visual indent
+    E127,
+    # continuation line under-indented for visual indent
+    E128,
+    # continuation line unaligned for hanging indent 
+    E131,
+    # module level import not at top of file 
+    E402,
+    # line too long 
+    E501,
+    # do not use bare 'except'
+    E722,
+    # line break after binary operator 
+    W504


### PR DESCRIPTION
See:
- https://github.com/PyCQA/flake8/issues/1760

From https://flake8.pycqa.org/en/latest/user/configuration.html :
> Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
```
[flake8]
per-file-ignores =
    # imported but unused
    __init__.py: F401
```
> this is not:
```
[flake8]
per-file-ignores =
    __init__.py: F401 # imported but unused
```

Same of https://github.com/kivy/python-for-android/pull/2708


I also took the occasion to do some cleanup.