### PR TITLE
Update Python versions in test matrix

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -6,9 +6,11 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.6'
            - '3.7'
            - '3.8'
+           - '3.9'
+           - '3.10'
+           - '3.11'
         os:
           - 'ubuntu-latest'
           - 'macOs-latest'


### PR DESCRIPTION
Python `3.6` reached EOL and is not available anymore on Github Actions.

This PR removes `3.6` from test matrix and adds `3.9`, `3.10` and `3.11`