### PR TITLE
Makes orientation option cross-platform and conform to latest python-for-android changes, adds `android.manifest.orientation`.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -410,10 +410,10 @@ class Buildozer:
             adderror('[app] "version.filename" is missing'
                      ', required by "version.regex"')
 
-        orientation = get('app', 'orientation', 'landscape')
-        if orientation not in ('landscape', 'portrait', 'all', 'sensorLandscape'):
-            adderror('[app] "orientation" have an invalid value')
-
+        orientation = self.config.getlist("app", "orientation", ["landscape"])
+        for o in orientation:
+            if o not in ("landscape", "portrait", "landscape-reverse", "portrait-reverse"):
+                adderror(f'[app] "{o}" is not a valid  value for "orientation"')
         if errors:
             self.error('{0} error(s) found in the buildozer.spec'.format(
                 len(errors)))

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -49,7 +49,8 @@ requirements = python3,kivy
 # (str) Icon of the application
 #icon.filename = %(source.dir)s/data/icon.png
 
-# (str) Supported orientation (one of landscape, sensorLandscape, portrait or all)
+# (list) Supported orientations
+# Valid options are: landscape, portrait, portrait-reverse or landscape-reverse
 orientation = portrait
 
 # (list) List of service to declare
@@ -241,6 +242,10 @@ fullscreen = 0
 
 # (str) launchMode to set for the main activity
 #android.manifest.launch_mode = standard
+
+# (str) screenOrientation to set for the main activity.
+# Valid values can be found at https://developer.android.com/guide/topics/manifest/activity-element
+#android.manifest.orientation = fullSensor
 
 # (list) Android additional libraries to copy into libs/armeabi
 #android.add_libs_armeabi = libs/android/*.so

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1257,10 +1257,9 @@ class TargetAndroid(Target):
 
         if config.getdefault('app', 'p4a.bootstrap', 'sdl2') != 'service_only':
             # add orientation
-            orientation = config.getdefault('app', 'orientation', 'landscape')
-            if orientation == 'all':
-                orientation = 'sensor'
-            build_cmd += [("--orientation", orientation)]
+            orientation = config.getlist('app', 'orientation', ['landscape'])
+            for orient in orientation:
+                build_cmd += [("--orientation", orient)]
 
             # fullscreen ?
             fullscreen = config.getbooldefault('app', 'fullscreen', True)
@@ -1291,6 +1290,12 @@ class TargetAndroid(Target):
             'app', 'android.manifest.launch_mode', '')
         if launch_mode:
             build_cmd += [("--activity-launch-mode", launch_mode)]
+
+        # screenOrientation
+        manifest_orientation = config.getdefault(
+            'app', 'android.manifest.orientation', '')
+        if manifest_orientation:
+            build_cmd += [("--manifest-orientation", manifest_orientation)]
 
         # numeric version
         numeric_version = config.getdefault('app', 'android.numeric_version')

--- a/docs/source/specifications.rst
+++ b/docs/source/specifications.rst
@@ -115,10 +115,11 @@ Section [app]
   The icon of your application. It must be a PNG of 512x512 size to be able to
   cover all the various platform requirements.
 
-- `orientation`: String, orientation of the application.
+- `orientation`: List, supported orientations of the application.
 
-  Indicate the orientation that your application supports. Defaults to
-  `landscape`, but can be changed to `portrait` or `all`.
+  Indicate the orientations that your application supports.
+  Valid values are: `portrait`, `landscape`, `portrait-reverse`, `landscape-reverse`.
+  Defaults to `[landscape]`.
 
 - `fullscreen`: Boolean, fullscreen mode.
 

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -462,3 +462,55 @@ class TestTargetAndroid:
         assert mock.call(
             ["git", "clone", "-b", "master", "--single-branch", "https://github.com/kivy/python-for-android.git", "python-for-android"],
             cwd=mock.ANY) in m_cmd.call_args_list
+
+    def test_orientation(self):
+        target_android = init_target(self.temp_dir, {
+            "orientation": "portrait,portrait-reverse"
+        })
+        buildozer = target_android.buildozer
+        m_execute_build_package = call_build_package(target_android)
+        assert m_execute_build_package.call_args_list == [
+            mock.call(
+                [
+                    ("--name", "My Application"),
+                    ("--version", "0.1"),
+                    ("--package", "org.test.myapp"),
+                    ("--minsdk", "21"),
+                    ("--ndk-api", "21"),
+                    ("--private", "{buildozer_dir}/android/app".format(buildozer_dir=buildozer.buildozer_dir)),
+                    ("--android-entrypoint", "org.kivy.android.PythonActivity"),
+                    ("--android-apptheme", "@android:style/Theme.NoTitleBar"),
+                    ("--orientation", "portrait"),
+                    ("--orientation", "portrait-reverse"),
+                    ("--window",),
+                    ('--enable-androidx',),
+                    ("debug",),
+                ]
+            )
+        ]
+
+    def test_manifest_orientation(self):
+        target_android = init_target(self.temp_dir, {
+            "android.manifest.orientation": "fullSensor"
+        })
+        buildozer = target_android.buildozer
+        m_execute_build_package = call_build_package(target_android)
+        assert m_execute_build_package.call_args_list == [
+            mock.call(
+                [
+                    ("--name", "My Application"),
+                    ("--version", "0.1"),
+                    ("--package", "org.test.myapp"),
+                    ("--minsdk", "21"),
+                    ("--ndk-api", "21"),
+                    ("--private", "{buildozer_dir}/android/app".format(buildozer_dir=buildozer.buildozer_dir)),
+                    ("--android-entrypoint", "org.kivy.android.PythonActivity"),
+                    ("--android-apptheme", "@android:style/Theme.NoTitleBar"),
+                    ("--orientation", "portrait"),
+                    ("--window",),
+                    ('--enable-androidx',),
+                    ("--manifest-orientation", "fullSensor"),
+                    ("debug",),
+                ]
+            )
+        ]


### PR DESCRIPTION
Related `python-for-android` PR: https://github.com/kivy/python-for-android/pull/2739

- `orientation` option is now (as it should be) cross-platform, and does not accepts values which are only available on Android `screenOrientation` setting.
- `android.manifest.orientation` offers an additional layer of control for users that need to set a specific `screenOrientation` into the `AndroidManifest.xml` file.
