### PR TITLE
Removes broken and unneeded checks, now we can support additional permission syntaxes.

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -93,7 +93,8 @@ fullscreen = 0
 #icon.adaptive_background.filename = %(source.dir)s/data/icon_bg.png
 
 # (list) Permissions
-#android.permissions = INTERNET
+# (See https://python-for-android.readthedocs.io/en/latest/buildoptions/#build-options-1 for all the supported syntaxes and properties)
+#android.permissions = android.permission.INTERNET, (name=android.permission.WRITE_EXTERNAL_STORAGE;maxSdkVersion=18)
 
 # (list) features (adds uses-feature -tags to manifest)
 #android.features = android.hardware.usb.host

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -176,7 +176,7 @@ class TestTargetAndroid:
             "buildozer.targets.android.Target.check_configuration_tokens"
         ) as m_check_configuration_tokens:
             target_android.check_configuration_tokens()
-        assert m_check_configuration_tokens.call_args_list == [mock.call([])]
+        assert m_check_configuration_tokens.call_args_list == [mock.call()]
 
     @pytest.mark.parametrize("platform", ["linux", "darwin"])
     def test_install_android_sdk(self, platform):


### PR DESCRIPTION
Related python-for-android PR: https://github.com/kivy/python-for-android/pull/2725

`android.permissions` now accepts all the syntaxes supported by `python-for-android`.


Removed broken and un-needed checks related to android permissions:

- `_get_available_permissions ` is looking for a file that does not exist anymore at the provided location, so everything is already considered "ok". Basically the check is already skipped.
- Forcing the last component to be uppercase can lead to multiple issues.


In general, IMHO is better to leave the error-handling for Android-specific things to the Android toolchain (or to `python-for-android` if it makes sense), as these things change fast .