### PR TITLE
Corrections (fixes) for extra-manifest-xml

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -884,14 +884,15 @@ class TargetAndroid(Target):
         extra_manifest_xml = self.buildozer.config.getdefault(
             'app', 'android.extra_manifest_xml', '')
         if extra_manifest_xml:
-            cmd.append('--extra-manifest-xml="{}"'.format(open(extra_manifest_xml, 'rt').read()))
+            cmd.append('--extra-manifest-xml')
+            cmd.append('{}'.format(open(extra_manifest_xml, 'rt').read()))
 
         # support for extra-manifest-application-arguments
         extra_manifest_application_arguments = self.buildozer.config.getdefault(
             'app', 'android.extra_manifest_application_arguments', '')
         if extra_manifest_application_arguments:
-            args_body = open(extra_manifest_application_arguments, 'rt').read().replace('"', '\\"').replace('\n', ' ').replace('\t', ' ')
-            cmd.append('--extra-manifest-application-arguments="{}"'.format(args_body))
+            cmd.append('--extra-manifest-application-arguments')
+            cmd.append('{}'.format(open(extra_manifest_application_arguments, 'rt').read()))
 
         # support for gradle dependencies
         gradle_dependencies = self.buildozer.config.getlist('app', 'android.gradle_dependencies', [])


### PR DESCRIPTION
Corrections for:
    - extra-manifest-xml
    - extra-nanifest-application-attributes

following issues detected:

android.features = android.hardware.sensor.accelerometer
results in:

toolchain.py: error: unrecognized arguments: --feature android.hardware.sensor.accelerometer

as a workaround I tried to supply a file containing the xml like:

android.extra_manifest_xml = ./xml/feature.xml

then toolchain parameter generated bei buildozer is wrong.
`... , '--extra-manifest-xml="<uses-feature\n      android:name="android.hardware.sensor.accelerometer"\n        android:required="true" />\n"', ...
`
p4a adds all contents after the equal sign to AndroidManifest, i.e including these additional double quotes - this is not correct.

After my change this works correctly. It produces the toolchainparameter (in 2 pieces) as:

`... , '--extra-manifest-xml', '<uses-feature\n        android:name="android.hardware.sensor.accelerometer"\n        android:required="true" />\n', ...
`
The same change is needed for extra_manifest_application_arguments.

This also fixes issue #1535.
