### PR TITLE
Update the suggested `Cython` version in docs to `0.29.33`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ WORKDIR ${WORK_DIR}
 COPY --chown=user:user . ${SRC_DIR}
 
 # installs buildozer and dependencies
-RUN pip3 install --user --upgrade Cython==0.29.19 wheel pip virtualenv ${SRC_DIR}
+RUN pip3 install --user --upgrade Cython==0.29.33 wheel pip virtualenv ${SRC_DIR}
 
 ENTRYPOINT ["buildozer"]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,7 +23,7 @@ Android on Ubuntu 20.04 and 22.04 (64bit)
 
     sudo apt update
     sudo apt install -y git zip unzip openjdk-17-jdk python3-pip autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev
-    pip3 install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
+    pip3 install --user --upgrade Cython==0.29.33 virtualenv  # the --user should be removed if you do this in a venv
 
     # add the following line at the end of your ~/.bashrc file
     export PATH=$PATH:~/.local/bin/
@@ -64,7 +64,7 @@ Android on macOS
     brew install openssl
     sudo ln -sfn /usr/local/opt/openssl /usr/local/ssl
     brew install pkg-config autoconf automake
-    python3 -m pip install --user --upgrade Cython==0.29.19 virtualenv  # the --user should be removed if you do this in a venv
+    python3 -m pip install --user --upgrade Cython==0.29.33 virtualenv  # the --user should be removed if you do this in a venv
 
     # add the following line at the end of your `~/.bashrc` file
     export PATH=$PATH:~/Library/Python/3.7/bin


### PR DESCRIPTION
As a user has reported here: https://github.com/kivy/buildozer/issues/1565 (and on Discord), `Cython==0.29.19` is not working anymore with the `develop` branch of `python-for-android`.

This PR updates the suggested version in docs.