### PR TITLE
`python-for-android` does not support `--dir` flag anymore.

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -115,9 +115,6 @@ fullscreen = 0
 # (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
 #android.ndk_api = 21
 
-# (bool) Use --private data storage (True) or --dir public storage (False)
-#android.private_storage = True
-
 # (str) Android NDK directory (if empty, it will be automatically downloaded.)
 #android.ndk_path =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1063,13 +1063,8 @@ class TargetAndroid(Target):
                                            self.android_minapi)),
             ("--ndk-api", config.getdefault('app', 'android.minapi',
                                             self.android_minapi)),
+            ("--private", self.buildozer.app_dir),
         ]
-        is_private_storage = config.getbooldefault(
-            'app', 'android.private_storage', True)
-        if is_private_storage:
-            build_cmd += [("--private", self.buildozer.app_dir)]
-        else:
-            build_cmd += [("--dir", self.buildozer.app_dir)]
 
         # add permissions
         permissions = config.getlist('app', 'android.permissions', [])


### PR DESCRIPTION
`python-for-android` does not support `public` storage anymore (since a while), and therefore does not support `--dir` flag.

Ref: https://github.com/kivy/python-for-android/issues/363

Fixes issue #1591 