### PR TITLE
Update ios_deploy branch to 1.12.2 Needed for latest Xcode.

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -368,7 +368,7 @@ ios.kivy_ios_branch = master
 #ios.ios_deploy_dir = ../ios_deploy
 # Or specify URL and branch
 ios.ios_deploy_url = https://github.com/phonegap/ios-deploy
-ios.ios_deploy_branch = 1.10.0
+ios.ios_deploy_branch = 1.12.2
 
 # (bool) Whether or not to sign the code
 ios.codesign.allowed = false

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -129,7 +129,7 @@ class TestTargetIos:
                     "git",
                     "clone",
                     "--branch",
-                    "1.10.0",
+                    "1.12.2",
                     "https://github.com/phonegap/ios-deploy",
                 ],
                 cwd=mock.ANY,


### PR DESCRIPTION
Latest Xcode removes support for older simulators and complains while trying to link

```
ld: file not found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a
```

Using latest branch from ios_deploy seems to fix the issue.
