### PR TITLE
display-cutout

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -163,7 +163,7 @@ fullscreen = 0
 # (list) Pattern to whitelist for the whole project
 #android.whitelist =
 
-# (bool) If True, your application will become into a launcher/home-app
+# (bool) If True, your application will be listed as a home app (launcher app)
 # android.home_app = False
 
 # (str) Path to a custom whitelist file

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -163,6 +163,9 @@ fullscreen = 0
 # (list) Pattern to whitelist for the whole project
 #android.whitelist =
 
+# (bool) If True, your application will become into a launcher/home-app
+# android.home_app = False
+
 # (str) Path to a custom whitelist file
 #android.whitelist_src =
 

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -163,6 +163,13 @@ fullscreen = 0
 # (bool) If True, your application will be listed as a home app (launcher app)
 # android.home_app = False
 
+# (str) Defaults to never for ignoring cutouts/notch
+# A display cutout is an area on some devices that extends into the display surface.
+# It allows for an edge-to-edge experience while providing space for important sensors on the front of the device.
+# Available options for Android API >= 28 are default, shortEdges, never and defaults to never.
+# Android documentation: https://developer.android.com/develop/ui/views/layout/display-cutout
+#android.display_cutout = never
+
 # (str) Path to a custom whitelist file
 #android.whitelist_src =
 

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -816,6 +816,11 @@ class TargetAndroid(Target):
         # Home-app usage
         if self.buildozer.config.getbooldefault('app', 'android.home_app', False):
             cmd.append("--home-app")
+        
+        # Enable display-cutout
+        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never')
+        if display_cutout in {'default', 'shortEdges'}:
+            cmd.append("--display-cutout={}".format(display_cutout))
 
         # support for recipes in a local directory within the project
         if local_recipes:

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -813,6 +813,10 @@ class TargetAndroid(Target):
         if self.buildozer.config.getbooldefault('app', 'android.copy_libs', True):
             cmd.append("--copy-libs")
 
+        # Home-app usage
+        if self.buildozer.config.getbooldefault('app', 'android.home_app', False):
+            cmd.append("--home-app")
+
         # support for recipes in a local directory within the project
         if local_recipes:
             cmd.append('--local-recipes')

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -823,8 +823,8 @@ class TargetAndroid(Target):
             cmd.append("--display-cutout={}".format(display_cutout))
         else:
             raise BuildozerException(
-                ("You have stated the wrong option for android.display_cutout. "
-                 "One of the following options are required: 'default', 'shortEdges' and 'never'.")
+                "You have stated the wrong option for android.display_cutout. "
+                "One of the following options are required: 'default', 'shortEdges' and 'never'.")
 
         # support for recipes in a local directory within the project
         if local_recipes:

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -819,8 +819,12 @@ class TargetAndroid(Target):
         
         # Enable display-cutout
         display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never')
-        if display_cutout in {'default', 'shortEdges'}:
+        if display_cutout in {'default', 'shortEdges', 'never'}:
             cmd.append("--display-cutout={}".format(display_cutout))
+        else:
+            raise BuildozerException(
+                ("You have stated the wrong option for android.display_cutout. "
+                 "One of the following options are required: 'default', 'shortEdges' and 'never'.")
 
         # support for recipes in a local directory within the project
         if local_recipes:

--- a/docs/source/specifications.rst
+++ b/docs/source/specifications.rst
@@ -129,5 +129,5 @@ Section [app]
 
 - `home_app`: Boolean, Home App (launcher app) usage.
 
-  Defaults to false, your application will be listed as a Home App (launcher app).
+  Defaults to false, your application will be listed as a Home App (launcher app) if true.
 

--- a/docs/source/specifications.rst
+++ b/docs/source/specifications.rst
@@ -127,3 +127,7 @@ Section [app]
   bar will be hidden. If you want to let the user access the status bar,
   hour, notifications, use 0 as a value.
 
+- `home_app`: Boolean, Home App (launcher app) usage.
+
+  Defaults to false, your application will be listed as a Home App (launcher app).
+

--- a/docs/source/specifications.rst
+++ b/docs/source/specifications.rst
@@ -131,3 +131,6 @@ Section [app]
 
   Defaults to false, your application will be listed as a Home App (launcher app) if true.
 
+- `display_cutout`: String, display-cutout mode to be used.
+
+  Defaults to `never`. Application will render around the cutout (notch) if set to either `default`, `shortEdges`.


### PR DESCRIPTION
A display cutout is an area on some devices that extends into the display surface.
It allows for an edge-to-edge experience while providing space for important sensors on the front of the device.
(Available options for Android `API >= 28` are `default`, `shortEdges`, `never` and defaults to `never`)
Android documentation <https://developer.android.com/develop/ui/views/layout/display-cutout>