### PR TITLE
Update default.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -323,7 +323,7 @@ android.allow_backup = True
 # (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
 #p4a.commit = HEAD
 
-# (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
+# (str) python-for-android git clone directory
 #p4a.source_dir =
 
 # (str) The directory in which python-for-android should look for your own build recipes (if any)


### PR DESCRIPTION
In buildozer.spec

> \# (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
> \# p4a.source_dir = ../python-for-android

p4a is not automatically cloned.  Log message is 

> \# Install platform
> \# Failed to read python-for-android setup.py at ../python-for-android/setup.py

Change doc string to 

> \# (str) python-for-android git clone directory