### PR TITLE
Refactor checkbin to use shutil.which

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -22,7 +22,7 @@ from os.path import join, exists, dirname, realpath, splitext, expanduser
 from subprocess import Popen, PIPE, TimeoutExpired
 from os import environ, unlink, walk, sep, listdir, makedirs
 from copy import copy
-from shutil import copyfile, rmtree, copytree, move
+from shutil import copyfile, rmtree, copytree, move, which
 from fnmatch import fnmatch
 
 from pprint import pformat
@@ -243,13 +243,10 @@ class Buildozer:
 
     def checkbin(self, msg, fn):
         self.debug('Search for {0}'.format(msg))
-        if exists(fn):
-            return realpath(fn)
-        for dn in environ['PATH'].split(':'):
-            rfn = realpath(join(dn, fn))
-            if exists(rfn):
-                self.debug(' -> found at {0}'.format(rfn))
-                return rfn
+        executable_location = which(fn)
+        if executable_location:
+            self.debug(' -> found at {0}'.format(executable_location))
+            return realpath(executable_location)
         self.error('{} not found, please install it.'.format(msg))
         exit(1)
 


### PR DESCRIPTION
checkbin used custom code to find where a binary is on the path. 
shutil.which is a built-in to do the same thing since Python 3.3. 
Simpler and works across platforms.