### PR TITLE
Factor out logging code from Buildozer class

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -912,9 +912,6 @@ class Buildozer:
                 yield target, m
             except NotImplementedError:
                 pass
-            except:
-                raise
-                pass
 
     def usage(self):
         print('Usage:')

--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -16,6 +16,7 @@ import codecs
 import textwrap
 import warnings
 from buildozer.jsonstore import JsonStore
+from buildozer.logger import Logger
 from sys import stdout, stderr, exit
 from re import search
 from os.path import join, exists, dirname, realpath, splitext, expanduser
@@ -25,7 +26,6 @@ from copy import copy
 from shutil import copyfile, rmtree, copytree, move, which
 from fnmatch import fnmatch
 
-from pprint import pformat
 import shlex
 import pexpect
 
@@ -36,41 +36,6 @@ try:
 except ImportError:
     # on windows, no fcntl
     fcntl = None
-try:
-    # if installed, it can give color to windows as well
-    import colorama
-    colorama.init()
-
-    RESET_SEQ = colorama.Fore.RESET + colorama.Style.RESET_ALL
-    COLOR_SEQ = lambda x: x  # noqa: E731
-    BOLD_SEQ = ''
-    if sys.platform == 'win32':
-        BLACK = colorama.Fore.BLACK + colorama.Style.DIM
-    else:
-        BLACK = colorama.Fore.BLACK + colorama.Style.BRIGHT
-    RED = colorama.Fore.RED
-    BLUE = colorama.Fore.CYAN
-    USE_COLOR = 'NO_COLOR' not in environ
-
-except ImportError:
-    if sys.platform != 'win32':
-        RESET_SEQ = "\033[0m"
-        COLOR_SEQ = lambda x: "\033[1;{}m".format(30 + x)  # noqa: E731
-        BOLD_SEQ = "\033[1m"
-        BLACK = 0
-        RED = 1
-        BLUE = 4
-        USE_COLOR = 'NO_COLOR' not in environ
-    else:
-        RESET_SEQ = ''
-        COLOR_SEQ = ''
-        BOLD_SEQ = ''
-        RED = BLUE = BLACK = 0
-        USE_COLOR = False
-
-# error, info, debug
-LOG_LEVELS_C = (RED, BLUE, BLACK)
-LOG_LEVELS_T = 'EID'
 SIMPLE_HTTP_SERVER_PORT = 8000
 
 
@@ -101,15 +66,10 @@ class BuildozerCommandException(BuildozerException):
 
 class Buildozer:
 
-    ERROR = 0
-    INFO = 1
-    DEBUG = 2
-
     standard_cmds = ('distclean', 'update', 'debug', 'release',
                      'deploy', 'run', 'serve')
 
     def __init__(self, filename='buildozer.spec', target=None):
-        self.log_level = 2
         self.environ = {}
         self.specfilename = filename
         self.state = None
@@ -123,6 +83,8 @@ class Buildozer:
         self.config.getbooldefault = self._get_config_bool
         self.config.getrawdefault = self._get_config_raw_default
 
+        self.logger = Logger()
+
         if exists(filename):
             self.config.read(filename, "utf-8")
             self.check_configuration_tokens()
@@ -132,8 +94,9 @@ class Buildozer:
         set_config_from_envs(self.config)
 
         try:
-            self.log_level = int(self.config.getdefault(
-                'buildozer', 'log_level', '2'))
+            self.logger.set_level(
+                int(self.config.getdefault(
+                    'buildozer', 'log_level', '2')))
         except Exception:
             pass
 
@@ -163,20 +126,20 @@ class Buildozer:
         if hasattr(self.target, '_build_prepared'):
             return
 
-        self.info('Preparing build')
+        self.logger.info('Preparing build')
 
-        self.info('Check requirements for {0}'.format(self.targetname))
+        self.logger.info('Check requirements for {0}'.format(self.targetname))
         self.target.check_requirements()
 
-        self.info('Install platform')
+        self.logger.info('Install platform')
         self.target.install_platform()
 
-        self.info('Check application requirements')
+        self.logger.info('Check application requirements')
         self.check_application_requirements()
 
         self.check_garden_requirements()
 
-        self.info('Compile platform')
+        self.logger.info('Compile platform')
         self.target.compile_platform()
 
         # flag to prevent multiple build
@@ -200,54 +163,26 @@ class Buildozer:
         self.build_id = int(self.state.get('cache.build_id', '0')) + 1
         self.state['cache.build_id'] = str(self.build_id)
 
-        self.info('Build the application #{}'.format(self.build_id))
+        self.logger.info('Build the application #{}'.format(self.build_id))
         self.build_application()
 
-        self.info('Package the application')
+        self.logger.info('Package the application')
         self.target.build_package()
 
         # flag to prevent multiple build
         self.target._build_done = True
 
     #
-    # Log functions
-    #
-
-    def log(self, level, msg):
-        if level > self.log_level:
-            return
-        if USE_COLOR:
-            color = COLOR_SEQ(LOG_LEVELS_C[level])
-            print(''.join((RESET_SEQ, color, '# ', msg, RESET_SEQ)))
-        else:
-            print('{} {}'.format(LOG_LEVELS_T[level], msg))
-
-    def debug(self, msg):
-        self.log(self.DEBUG, msg)
-
-    def log_env(self, level, env):
-        """dump env into debug logger in readable format"""
-        self.log(level, "ENVIRONMENT:")
-        for k, v in env.items():
-            self.log(level, "    {} = {}".format(k, pformat(v)))
-
-    def info(self, msg):
-        self.log(self.INFO, msg)
-
-    def error(self, msg):
-        self.log(self.ERROR, msg)
-
-    #
     # Internal check methods
     #
 
     def checkbin(self, msg, fn):
-        self.debug('Search for {0}'.format(msg))
+        self.logger.debug('Search for {0}'.format(msg))
         executable_location = which(fn)
         if executable_location:
-            self.debug(' -> found at {0}'.format(executable_location))
+            self.logger.debug(' -> found at {0}'.format(executable_location))
             return realpath(executable_location)
-        self.error('{} not found, please install it.'.format(msg))
+        self.logger.error('{} not found, please install it.'.format(msg))
         exit(1)
 
     def cmd(self, command, **kwargs):
@@ -260,7 +195,7 @@ class Buildozer:
         kwargs.setdefault('stdout', PIPE)
         kwargs.setdefault('stderr', PIPE)
         kwargs.setdefault('close_fds', True)
-        kwargs.setdefault('show_output', self.log_level > 1)
+        kwargs.setdefault('show_output', self.logger.log_level > 1)
 
         show_output = kwargs.pop('show_output')
         get_stdout = kwargs.pop('get_stdout', False)
@@ -272,13 +207,13 @@ class Buildozer:
 
         if not quiet:
             if not sensible:
-                self.debug('Run {0!r}'.format(command))
+                self.logger.debug('Run {0!r}'.format(command))
             else:
                 if isinstance(command, (list, tuple)):
-                    self.debug('Run {0!r} ...'.format(command[0]))
+                    self.logger.debug('Run {0!r} ...'.format(command[0]))
                 else:
-                    self.debug('Run {0!r} ...'.format(command.split()[0]))
-            self.debug('Cwd {}'.format(kwargs.get('cwd')))
+                    self.logger.debug('Run {0!r} ...'.format(command.split()[0]))
+            self.logger.debug('Cwd {}'.format(kwargs.get('cwd')))
 
         # open the process
         if sys.platform == 'win32':
@@ -331,18 +266,18 @@ class Buildozer:
             pass
 
         if process.returncode != 0 and break_on_error:
-            self.error('Command failed: {0}'.format(command))
-            self.log_env(self.ERROR, kwargs['env'])
-            self.error('')
-            self.error('Buildozer failed to execute the last command')
-            if self.log_level <= self.INFO:
-                self.error('If the error is not obvious, please raise the log_level to 2')
-                self.error('and retry the latest command.')
+            self.logger.error('Command failed: {0}'.format(command))
+            self.logger.log_env(self.logger.ERROR, kwargs['env'])
+            self.logger.error('')
+            self.logger.error('Buildozer failed to execute the last command')
+            if self.logger.log_level <= self.logger.INFO:
+                self.logger.error('If the error is not obvious, please raise the log_level to 2')
+                self.logger.error('and retry the latest command.')
             else:
-                self.error('The error might be hidden in the log above this error')
-                self.error('Please read the full log, and search for it before')
-                self.error('raising an issue with buildozer itself.')
-            self.error('In case of a bug report, please add a full log with log_level = 2')
+                self.logger.error('The error might be hidden in the log above this error')
+                self.logger.error('Please read the full log, and search for it before')
+                self.logger.error('raising an issue with buildozer itself.')
+            self.logger.error('In case of a bug report, please add a full log with log_level = 2')
             raise BuildozerCommandException()
 
         if ret_stdout:
@@ -362,7 +297,7 @@ class Buildozer:
 
         # prepare the process
         kwargs.setdefault('env', env)
-        kwargs.setdefault('show_output', self.log_level > 1)
+        kwargs.setdefault('show_output', self.logger.log_level > 1)
         sensible = kwargs.pop('sensible', False)
         show_output = kwargs.pop('show_output')
 
@@ -370,17 +305,17 @@ class Buildozer:
             kwargs['logfile'] = codecs.getwriter('utf8')(stdout.buffer)
 
         if not sensible:
-            self.debug('Run (expect) {0!r}'.format(command))
+            self.logger.debug('Run (expect) {0!r}'.format(command))
         else:
-            self.debug('Run (expect) {0!r} ...'.format(command.split()[0]))
+            self.logger.debug('Run (expect) {0!r} ...'.format(command.split()[0]))
 
-        self.debug('Cwd {}'.format(kwargs.get('cwd')))
+        self.logger.debug('Cwd {}'.format(kwargs.get('cwd')))
         return pexpect.spawnu(shlex.join(command), **kwargs)
 
     def check_configuration_tokens(self):
         '''Ensure the spec file is 'correct'.
         '''
-        self.info('Check configuration tokens')
+        self.logger.info('Check configuration tokens')
         self.migrate_configuration_tokens()
         get = self.config.getdefault
         errors = []
@@ -412,7 +347,7 @@ class Buildozer:
             if o not in ("landscape", "portrait", "landscape-reverse", "portrait-reverse"):
                 adderror(f'[app] "{o}" is not a valid  value for "orientation"')
         if errors:
-            self.error('{0} error(s) found in the buildozer.spec'.format(
+            self.logger.error('{0} error(s) found in the buildozer.spec'.format(
                 len(errors)))
             for error in errors:
                 print(error)
@@ -435,14 +370,14 @@ class Buildozer:
                 value = config.get("app", entry_old)
                 config.set("app", entry_new, value)
                 config.remove_option("app", entry_old)
-                self.error("In section [app]: {} is deprecated, rename to {}!".format(
+                self.logger.error("In section [app]: {} is deprecated, rename to {}!".format(
                     entry_old, entry_new))
 
     def check_build_layout(self):
         '''Ensure the build (local and global) directory layout and files are
         ready.
         '''
-        self.info('Ensure build layout')
+        self.logger.info('Ensure build layout')
 
         if not exists(self.specfilename):
             print('No {0} found in the current directory. Abandon.'.format(
@@ -483,7 +418,7 @@ class Buildozer:
                         target_available_packages]
 
         if requirements and hasattr(sys, 'real_prefix'):
-            e = self.error
+            e = self.logger.error
             e('virtualenv is needed to install pure-Python modules, but')
             e('virtualenv does not support nesting, and you are running')
             e('buildozer in one. Please run buildozer outside of a')
@@ -495,7 +430,7 @@ class Buildozer:
             exists(self.applibs_dir) and
             self.state.get('cache.applibs', '') == requirements
         ):
-            self.debug('Application requirements already installed, pass')
+            self.logger.debug('Application requirements already installed, pass')
             return
 
         # recreate applibs
@@ -511,7 +446,7 @@ class Buildozer:
 
     def _install_application_requirement(self, module):
         self._ensure_virtualenv()
-        self.debug('Install requirement {} in virtualenv'.format(module))
+        self.logger.debug('Install requirement {} in virtualenv'.format(module))
         self.cmd(
             ["pip", "install", f"--target={self.applibs_dir}", module],
             env=self.env_venv,
@@ -556,13 +491,13 @@ class Buildozer:
     def mkdir(self, dn):
         if exists(dn):
             return
-        self.debug('Create directory {0}'.format(dn))
+        self.logger.debug('Create directory {0}'.format(dn))
         makedirs(dn)
 
     def rmdir(self, dn):
         if not exists(dn):
             return
-        self.debug('Remove directory and subdirectory {}'.format(dn))
+        self.logger.debug('Remove directory and subdirectory {}'.format(dn))
         rmtree(dn)
 
     def file_matches(self, patterns):
@@ -580,9 +515,9 @@ class Buildozer:
         if cwd:
             source = join(cwd, source)
             target = join(cwd, target)
-        self.debug('Rename {0} to {1}'.format(source, target))
+        self.logger.debug('Rename {0} to {1}'.format(source, target))
         if not os.path.isdir(os.path.dirname(target)):
-            self.error(('Rename {0} to {1} fails because {2} is not a '
+            self.logger.error(('Rename {0} to {1} fails because {2} is not a '
                         'directory').format(source, target, target))
         move(source, target)
 
@@ -590,7 +525,7 @@ class Buildozer:
         if cwd:
             source = join(cwd, source)
             target = join(cwd, target)
-        self.debug('Copy {0} to {1}'.format(source, target))
+        self.logger.debug('Copy {0} to {1}'.format(source, target))
         copyfile(source, target)
 
     def file_extract(self, archive, cwd=None):
@@ -629,7 +564,7 @@ class Buildozer:
             copyfile(src, dest)
 
     def clean_platform(self):
-        self.info('Clean the platform build directory')
+        self.logger.info('Clean the platform build directory')
         if not exists(self.platform_dir):
             return
         rmtree(self.platform_dir)
@@ -651,7 +586,7 @@ class Buildozer:
         if self.file_exists(filename):
             unlink(filename)
 
-        self.debug('Downloading {0}'.format(url))
+        self.logger.debug('Downloading {0}'.format(url))
         urlretrieve(url, filename, report_hook)
         return filename
 
@@ -685,7 +620,7 @@ class Buildozer:
                         'Unable to find capture version in {0}\n'
                         ' (looking for `{1}`)'.format(fn, regex))
                 version = match.groups()[0]
-                self.debug('Captured version: {0}'.format(version))
+                self.logger.debug('Captured version: {0}'.format(version))
                 return version
 
         raise Exception('Missing version or version.regex + version.filename')
@@ -713,7 +648,7 @@ class Buildozer:
         exclude_patterns = [pat.lower() for pat in exclude_patterns]
         include_patterns = [pat.lower() for pat in include_patterns]
 
-        self.debug('Copy application source from {}'.format(source_dir))
+        self.logger.debug('Copy application source from {}'.format(source_dir))
 
         rmtree(self.app_dir)
 
@@ -792,7 +727,7 @@ class Buildozer:
                 self.mkdir(dfn)
 
                 # copy!
-                self.debug('Copy {0}'.format(sfn))
+                self.logger.debug('Copy {0}'.format(sfn))
                 copyfile(sfn, rfn)
 
     def _copy_application_libs(self):
@@ -815,7 +750,7 @@ class Buildozer:
         data = header + data
         with open(main_py, 'wb') as fd:
             fd.write(data)
-        self.info('Patched service/main.py to include applibs')
+        self.logger.info('Patched service/main.py to include applibs')
 
     def namify(self, name):
         '''Return a "valid" name from a name with lot of invalid chars
@@ -979,7 +914,7 @@ class Buildozer:
             arg = args.pop(0)
 
             if arg in ('-v', '--verbose'):
-                self.log_level = 2
+                self.logger.set_level(2)
 
             elif arg in ('-h', '--help'):
                 self.usage()
@@ -1053,7 +988,7 @@ class Buildozer:
         print("Warning: Your ndk, sdk and all other cached packages will be"
               " removed. Continue? (y/n)")
         if sys.stdin.readline().lower()[0] == 'y':
-            self.info('Clean the global build directory')
+            self.logger.info('Clean the global build directory')
             if not exists(self.global_buildozer_dir):
                 return
             rmtree(self.global_buildozer_dir)
@@ -1066,14 +1001,14 @@ class Buildozer:
         more than the user intends.
         '''
         if self.user_build_dir is not None:
-            self.error(
+            self.logger.error(
                 ('Failed: build_dir is specified as {} in the buildozer config. `appclean` will '
                  'not attempt to delete files in a user-specified build directory.').format(self.user_build_dir))
         elif exists(self.buildozer_dir):
-            self.info('Deleting {}'.format(self.buildozer_dir))
+            self.logger.info('Deleting {}'.format(self.buildozer_dir))
             rmtree(self.buildozer_dir)
         else:
-            self.error('{} already deleted, skipping.'.format(self.buildozer_dir))
+            self.logger.error('{} already deleted, skipping.'.format(self.buildozer_dir))
 
     def cmd_help(self, *args):
         '''Show the Buildozer help.

--- a/buildozer/logger.py
+++ b/buildozer/logger.py
@@ -1,0 +1,87 @@
+"""
+Logger
+======
+
+Logger implementation used by Buildozer.
+
+Supports colored output, where available.
+"""
+
+from os import environ
+from pprint import pformat
+import sys
+
+try:
+    # if installed, it can give color to Windows as well
+    import colorama
+
+    colorama.init()
+except ImportError:
+    colorama = None
+
+# set color codes
+if colorama:
+    RESET_SEQ = colorama.Fore.RESET + colorama.Style.RESET_ALL
+    COLOR_SEQ = lambda x: x  # noqa: E731
+    BOLD_SEQ = ""
+    if sys.platform == "win32":
+        BLACK = colorama.Fore.BLACK + colorama.Style.DIM
+    else:
+        BLACK = colorama.Fore.BLACK + colorama.Style.BRIGHT
+    RED = colorama.Fore.RED
+    BLUE = colorama.Fore.CYAN
+    USE_COLOR = "NO_COLOR" not in environ
+elif sys.platform != "win32":
+    RESET_SEQ = "\033[0m"
+    COLOR_SEQ = lambda x: "\033[1;{}m".format(30 + x)  # noqa: E731
+    BOLD_SEQ = "\033[1m"
+    BLACK = 0
+    RED = 1
+    BLUE = 4
+    USE_COLOR = "NO_COLOR" not in environ
+else:
+    RESET_SEQ = ""
+    COLOR_SEQ = ""
+    BOLD_SEQ = ""
+    RED = BLUE = BLACK = 0
+    USE_COLOR = False
+
+
+class Logger:
+    ERROR = 0
+    INFO = 1
+    DEBUG = 2
+
+    LOG_LEVELS_C = (RED, BLUE, BLACK)  # Map levels to colors
+    LOG_LEVELS_T = "EID"  # error, info, debug
+
+    log_level = ERROR
+
+    def log(self, level, msg):
+        if level > self.log_level:
+            return
+        if USE_COLOR:
+            color = COLOR_SEQ(Logger.LOG_LEVELS_C[level])
+            print("".join((RESET_SEQ, color, "# ", msg, RESET_SEQ)))
+        else:
+            print("{} {}".format(Logger.LOG_LEVELS_T[level], msg))
+
+    def debug(self, msg):
+        self.log(self.DEBUG, msg)
+
+    def info(self, msg):
+        self.log(self.INFO, msg)
+
+    def error(self, msg):
+        self.log(self.ERROR, msg)
+
+    def log_env(self, level, env):
+        """dump env into logger in readable format"""
+        self.log(level, "ENVIRONMENT:")
+        for k, v in env.items():
+            self.log(level, "    {} = {}".format(k, pformat(v)))
+
+    @classmethod
+    def set_level(cls, level):
+        """set minimum threshold for log messages"""
+        cls.log_level = level

--- a/buildozer/scripts/client.py
+++ b/buildozer/scripts/client.py
@@ -6,6 +6,7 @@ Main Buildozer client
 
 import sys
 from buildozer import Buildozer, BuildozerCommandException, BuildozerException
+from buildozer.logger import Logger
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
         # the command failed.
         sys.exit(1)
     except BuildozerException as error:
-        Buildozer().error('%s' % error)
+        Logger().error('%s' % error)
         sys.exit(1)
 
 

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -17,6 +17,7 @@ import socket
 import sys
 from buildozer import (
     Buildozer, BuildozerCommandException, BuildozerException, __version__)
+from buildozer.logger import Logger
 from sys import stdout, stdin, exit
 from select import select
 from os.path import join, expanduser, realpath, exists, splitext
@@ -271,7 +272,7 @@ def main():
     except BuildozerCommandException:
         pass
     except BuildozerException as error:
-        Buildozer().error('%s' % error)
+        Logger().error('%s' % error)
 
 
 if __name__ == '__main__':

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -41,7 +41,7 @@ class BuildozerRemote(Buildozer):
             arg = args.pop(0)
 
             if arg in ('-v', '--verbose'):
-                self.log_level = 2
+                self.logger.log_level = 2
 
             elif arg in ('-p', '--profile'):
                 self.config_profile = args.pop(0)
@@ -63,7 +63,7 @@ class BuildozerRemote(Buildozer):
         remote_name = args[0]
         remote_section = 'remote:{}'.format(remote_name)
         if not self.config.has_section(remote_section):
-            self.error('Unknown remote "{}", must be configured first.'.format(
+            self.logger.error('Unknown remote "{}", must be configured first.'.format(
                 remote_name))
             return
 
@@ -78,13 +78,13 @@ class BuildozerRemote(Buildozer):
         self.remote_identity = self.config.get(
                 remote_section, 'identity', '')
         if not remote_host:
-            self.error('Missing "host = " for {}'.format(remote_section))
+            self.logger.error('Missing "host = " for {}'.format(remote_section))
             return
         if not remote_user:
-            self.error('Missing "user = " for {}'.format(remote_section))
+            self.logger.error('Missing "user = " for {}'.format(remote_section))
             return
         if not remote_build_dir:
-            self.error('Missing "build_directory = " for {}'.format(remote_section))
+            self.logger.error('Missing "build_directory = " for {}'.format(remote_section))
             return
 
         # fake the target
@@ -92,7 +92,7 @@ class BuildozerRemote(Buildozer):
         self.check_build_layout()
 
         # prepare our source code
-        self.info('Prepare source code to sync')
+        self.logger.info('Prepare source code to sync')
         self._copy_application_sources()
         self._ssh_connect()
         try:
@@ -104,7 +104,7 @@ class BuildozerRemote(Buildozer):
             self._ssh_close()
 
     def _ssh_connect(self):
-        self.info('Connecting to {}'.format(self.remote_host))
+        self.logger.info('Connecting to {}'.format(self.remote_host))
         self._ssh_client = client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         client.load_system_host_keys()
@@ -116,7 +116,7 @@ class BuildozerRemote(Buildozer):
         self._sftp_client = client.open_sftp()
 
     def _ssh_close(self):
-        self.debug('Closing remote connection')
+        self.logger.debug('Closing remote connection')
         self._sftp_client.close()
         self._ssh_client.close()
 
@@ -125,16 +125,16 @@ class BuildozerRemote(Buildozer):
         root_dir = s.normalize('.')
         self.remote_build_dir = join(root_dir, self.remote_build_dir,
                 self.package_full_name)
-        self.debug('Remote build directory: {}'.format(self.remote_build_dir))
+        self.logger.debug('Remote build directory: {}'.format(self.remote_build_dir))
         self._ssh_mkdir(self.remote_build_dir)
         self._ssh_sync(__path__[0])  # noqa: F821 undefined name
 
     def _sync_application_sources(self):
-        self.info('Synchronize application sources')
+        self.logger.info('Synchronize application sources')
         self._ssh_sync(self.app_dir)
 
         # create custom buildozer.spec
-        self.info('Create custom buildozer.spec')
+        self.logger.info('Create custom buildozer.spec')
         config = ConfigParser()
         config.read('buildozer.spec')
         config.set('app', 'source.dir', 'app')
@@ -145,7 +145,7 @@ class BuildozerRemote(Buildozer):
         fd.close()
 
     def _do_remote_commands(self, args):
-        self.info('Execute remote buildozer')
+        self.logger.info('Execute remote buildozer')
         cmd = (
             'source ~/.profile;'
             'cd {0};'
@@ -153,14 +153,14 @@ class BuildozerRemote(Buildozer):
             'python -c "import buildozer, sys;'
             'buildozer.Buildozer().run_command(sys.argv[1:])" {1} {2} 2>&1').format(
             self.remote_build_dir,
-            '--verbose' if self.log_level == 2 else '',
+            '--verbose' if self.logger.log_level == 2 else '',
             ' '.join(args),
         )
         self._ssh_command(cmd)
 
     def _ssh_mkdir(self, *args):
         directory = join(*args)
-        self.debug('Create remote directory {}'.format(directory))
+        self.logger.debug('Create remote directory {}'.format(directory))
         try:
             self._sftp_client.mkdir(directory)
         except IOError:
@@ -168,11 +168,11 @@ class BuildozerRemote(Buildozer):
             try:
                 self._sftp_client.stat(directory)
             except IOError:
-                self.error('Unable to create remote directory {}'.format(directory))
+                self.logger.error('Unable to create remote directory {}'.format(directory))
                 raise
 
     def _ssh_sync(self, directory, mode='put'):
-        self.debug('Syncing {} directory'.format(directory))
+        self.logger.debug('Syncing {} directory'.format(directory))
         directory = realpath(expanduser(directory))
         base_strip = directory.rfind('/')
         if mode == 'get':
@@ -191,11 +191,11 @@ class BuildozerRemote(Buildozer):
                     continue
                 local_file = join(root, fn)
                 remote_file = join(self.remote_build_dir, root[base_strip + 1:], fn)
-                self.debug('Sync {} -> {}'.format(local_file, remote_file))
+                self.logger.debug('Sync {} -> {}'.format(local_file, remote_file))
                 self._sftp_client.put(local_file, remote_file)
 
     def _ssh_command(self, command):
-        self.debug('Execute remote command {}'.format(command))
+        self.logger.debug('Execute remote command {}'.format(command))
         transport = self._ssh_client.get_transport()
         channel = transport.open_session()
         try:

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -2,6 +2,8 @@ from sys import exit
 import os
 from os.path import join
 
+from buildozer.logger import Logger
+
 
 def no_config(f):
     f.__no_config = True
@@ -14,16 +16,17 @@ class Target:
         self.build_mode = 'debug'
         self.artifact_format = 'apk'
         self.platform_update = False
+        self.logger = Logger()
 
     def check_requirements(self):
         pass
 
     def check_configuration_tokens(self, errors=None):
         if errors:
-            self.buildozer.info('Check target configuration tokens')
-            self.buildozer.error(
+            self.logger.info('Check target configuration tokens')
+            self.logger.error(
                 '{0} error(s) found in the buildozer.spec'.format(
-                len(errors)))
+                    len(errors)))
             for error in errors:
                 print(error)
             exit(1)
@@ -49,7 +52,7 @@ class Target:
 
     def run_commands(self, args):
         if not args:
-            self.buildozer.error('Missing target command')
+            self.logger.error('Missing target command')
             self.buildozer.usage()
             exit(1)
 
@@ -68,7 +71,7 @@ class Target:
                 last_command.append(arg)
             else:
                 if not last_command:
-                    self.buildozer.error('Argument passed without a command')
+                    self.logger.error('Argument passed without a command')
                     self.buildozer.usage()
                     exit(1)
                 last_command.append(arg)
@@ -80,7 +83,7 @@ class Target:
         for item in result:
             command, args = item[0], item[1:]
             if not hasattr(self, 'cmd_{0}'.format(command)):
-                self.buildozer.error('Unknown command {0}'.format(command))
+                self.logger.error('Unknown command {0}'.format(command))
                 exit(1)
 
             func = getattr(self, 'cmd_{0}'.format(command))
@@ -106,7 +109,7 @@ class Target:
         self.buildozer.build()
 
     def cmd_release(self, *args):
-        error = self.buildozer.error
+        error = self.logger.error
         self.buildozer.prepare_for_build()
         if self.buildozer.config.get("app", "package.domain") == "org.test":
             error("")

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -17,15 +17,15 @@ class TargetOSX(Target):
     targetname = "osx"
 
     def ensure_sdk(self):
-        self.buildozer.info('Check if kivy-sdk-packager exists')
+        self.logger.info('Check if kivy-sdk-packager exists')
         if exists(
                 join(self.buildozer.platform_dir, 'kivy-sdk-packager-master')):
-            self.buildozer.info(
+            self.logger.info(
                     'kivy-sdk-packager found at '
                     '{}'.format(self.buildozer.platform_dir))
             return
 
-        self.buildozer.info('kivy-sdk-packager does not exist, clone it')
+        self.logger.info('kivy-sdk-packager does not exist, clone it')
         platdir = self.buildozer.platform_dir
         check_call(
             ('curl', '-O', '-L',
@@ -38,14 +38,14 @@ class TargetOSX(Target):
         current_kivy_vers = self.buildozer.config.get('app', 'osx.kivy_version')
 
         if exists('/Applications/Kivy.app'):
-            self.buildozer.info('Kivy found in Applications dir...')
+            self.logger.info('Kivy found in Applications dir...')
             check_call(
                 ('cp', '-a', '/Applications/Kivy.app',
                     'Kivy.app'), cwd=cwd)
 
         else:
             if not exists(join(cwd, 'Kivy.dmg')):
-                self.buildozer.info('Downloading kivy...')
+                self.logger.info('Downloading kivy...')
                 status_code = check_output((
                     'curl', '-L', '--write-out', '%{http_code}',
                     '-o', 'Kivy.dmg',

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -1,17 +1,19 @@
-'''
+"""
 OSX target, based on kivy-sdk-packager
-'''
+"""
 
 import sys
 if sys.platform != 'darwin':
     raise NotImplementedError('This will only work on osx')
 
-from buildozer.target import Target
 from os.path import exists, join, abspath, dirname
 from subprocess import check_call, check_output
 
+from buildozer.target import Target
+
 
 class TargetOSX(Target):
+
     targetname = "osx"
 
     def ensure_sdk(self):
@@ -20,14 +22,14 @@ class TargetOSX(Target):
                 join(self.buildozer.platform_dir, 'kivy-sdk-packager-master')):
             self.buildozer.info(
                     'kivy-sdk-packager found at '
-                '{}'.format(self.buildozer.platform_dir))
+                    '{}'.format(self.buildozer.platform_dir))
             return
 
         self.buildozer.info('kivy-sdk-packager does not exist, clone it')
         platdir = self.buildozer.platform_dir
         check_call(
             ('curl', '-O', '-L',
-            'https://github.com/kivy/kivy-sdk-packager/archive/master.zip'),
+                'https://github.com/kivy/kivy-sdk-packager/archive/master.zip'),
             cwd=platdir)
         check_call(('unzip', 'master.zip'), cwd=platdir)
         check_call(('rm', 'master.zip'), cwd=platdir)
@@ -39,33 +41,34 @@ class TargetOSX(Target):
             self.buildozer.info('Kivy found in Applications dir...')
             check_call(
                 ('cp', '-a', '/Applications/Kivy.app',
-                'Kivy.app'), cwd=cwd)
+                    'Kivy.app'), cwd=cwd)
 
         else:
             if not exists(join(cwd, 'Kivy.dmg')):
                 self.buildozer.info('Downloading kivy...')
-                status_code = check_output(
-                    ('curl', '-L', '--write-out', '%{http_code}', '-o', 'Kivy.dmg',
+                status_code = check_output((
+                    'curl', '-L', '--write-out', '%{http_code}',
+                    '-o', 'Kivy.dmg',
                     f'https://kivy.org/downloads/{current_kivy_vers}/Kivy.dmg'),
                     cwd=cwd)
 
                 if status_code == "404":
-                    self.buildozer.error(
+                    self.logger.error(
                         "Unable to download the Kivy App. Check osx.kivy_version in your buildozer.spec, and verify "
                         "Kivy servers are accessible. https://kivy.org/downloads/")
                     check_call(("rm", "Kivy.dmg"), cwd=cwd)
                     sys.exit(1)
 
-            self.buildozer.info('Extracting and installing Kivy...')
+            self.logger.info('Extracting and installing Kivy...')
             check_call(('hdiutil', 'attach', cwd + '/Kivy.dmg'))
             check_call(('cp', '-a', '/Volumes/Kivy/Kivy.app', './Kivy.app'), cwd=cwd)
 
     def ensure_kivyapp(self):
-        self.buildozer.info('check if Kivy.app exists in local dir')
+        self.logger.info('check if Kivy.app exists in local dir')
         kivy_app_dir = join(self.buildozer.platform_dir, 'kivy-sdk-packager-master', 'osx')
 
         if exists(join(kivy_app_dir, 'Kivy.app')):
-            self.buildozer.info('Kivy.app found at ' + kivy_app_dir)
+            self.logger.info('Kivy.app found at ' + kivy_app_dir)
         else:
             self.download_kivy(kivy_app_dir)
 
@@ -75,17 +78,17 @@ class TargetOSX(Target):
 
     def check_configuration_tokens(self, errors=None):
         if errors:
-            self.buildozer.info('Check target configuration tokens')
-            self.buildozer.error(
+            self.logger.info('Check target configuration tokens')
+            self.logger.error(
                 '{0} error(s) found in the buildozer.spec'.format(
-                len(errors)))
+                    len(errors)))
             for error in errors:
                 print(error)
             sys.exit(1)
         # check
 
     def build_package(self):
-        self.buildozer.info('Building package')
+        self.logger.info('Building package')
 
         bc = self.buildozer.config
         bcg = bc.get
@@ -97,26 +100,28 @@ class TargetOSX(Target):
         version = self.buildozer.get_version()
         author = bc.getdefault('app', 'author', '')
 
-        self.buildozer.info('Create {}.app'.format(package_name))
+        self.logger.info('Create {}.app'.format(package_name))
         cwd = join(self.buildozer.platform_dir, 'kivy-sdk-packager-master', 'osx')
         # remove kivy from app_deps
         app_deps = [a for a in app_deps.split('\n') if not a.startswith('#') and a not in ['kivy', '']]
 
         cmd = [
             'Kivy.app/Contents/Resources/script',
-             '-m', 'pip', 'install',
+            '-m', 'pip', 'install',
              ]
         cmd.extend(app_deps)
         check_output(cmd, cwd=cwd)
 
         cmd = [
-            sys.executable, 'package_app.py', self.buildozer.app_dir,
+            sys.executable,
+            'package_app.py',
+            self.buildozer.app_dir,
             '--appname={}'.format(package_name),
-             '--bundlename={}'.format(title),
-             '--bundleid={}'.format(domain),
-             '--bundleversion={}'.format(version),
-             '--displayname={}'.format(title)
-             ]
+            '--bundlename={}'.format(title),
+            '--bundleid={}'.format(domain),
+            '--bundleversion={}'.format(version),
+            '--displayname={}'.format(title)
+              ]
         if icon:
             cmd.append('--icon={}'.format(icon))
         if author:
@@ -124,27 +129,27 @@ class TargetOSX(Target):
 
         check_output(cmd, cwd=cwd)
 
-        self.buildozer.info('{}.app created.'.format(package_name))
-        self.buildozer.info('Creating {}.dmg'.format(package_name))
+        self.logger.info('{}.app created.'.format(package_name))
+        self.logger.info('Creating {}.dmg'.format(package_name))
         check_output(
             ('sh', '-x', 'create-osx-dmg.sh', package_name + '.app', package_name, '-s', '1'),
             cwd=cwd)
-        self.buildozer.info('{}.dmg created'.format(package_name))
-        self.buildozer.info('moving {}.dmg to bin.'.format(package_name))
+        self.logger.info('{}.dmg created'.format(package_name))
+        self.logger.info('moving {}.dmg to bin.'.format(package_name))
         binpath = join(
             self.buildozer.user_build_dir or
             dirname(abspath(self.buildozer.specfilename)), 'bin')
         check_output(
             ('cp', '-a', package_name + '.dmg', binpath),
             cwd=cwd)
-        self.buildozer.info('All Done!')
+        self.logger.info('All Done!')
 
     def compile_platform(self):
         pass
 
     def install_platform(self):
         # ultimate configuration check.
-        # some of our configuration cannot be check without platform.
+        # some of our configuration cannot be checked without platform.
         self.check_configuration_tokens()
         #
         self.buildozer.environ.update({
@@ -166,7 +171,7 @@ class TargetOSX(Target):
 
     def run_commands(self, args):
         if not args:
-            self.buildozer.error('Missing target command')
+            self.logger.error('Missing target command')
             self.buildozer.usage()
             sys.exit(1)
 
@@ -180,7 +185,7 @@ class TargetOSX(Target):
                 last_command.append(arg)
             else:
                 if not last_command:
-                    self.buildozer.error('Argument passed without a command')
+                    self.logger.error('Argument passed without a command')
                     self.buildozer.usage()
                     sys.exit(1)
                 last_command.append(arg)
@@ -192,7 +197,7 @@ class TargetOSX(Target):
         for item in result:
             command, args = item[0], item[1:]
             if not hasattr(self, 'cmd_{0}'.format(command)):
-                self.buildozer.error('Unknown command {0}'.format(command))
+                self.logger.error('Unknown command {0}'.format(command))
                 sys.exit(1)
 
             func = getattr(self, 'cmd_{0}'.format(command))

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -10,8 +10,8 @@ from tests.targets.utils import (
     init_buildozer,
     patch_buildozer_checkbin,
     patch_buildozer_cmd,
-    patch_buildozer_error,
     patch_buildozer_file_exists,
+    patch_logger_error,
 )
 
 
@@ -195,7 +195,7 @@ class TestTargetIos:
         target.ios_dir = "/ios/dir"
         # fmt: off
         with patch_target_ios("_unlock_keychain") as m_unlock_keychain, \
-             patch_buildozer_error() as m_error, \
+             patch_logger_error() as m_error, \
              mock.patch("buildozer.targets.ios.TargetIos.load_plist_from_file") as m_load_plist_from_file, \
              mock.patch("buildozer.targets.ios.TargetIos.dump_plist_to_file") as m_dump_plist_to_file, \
              patch_buildozer_cmd() as m_cmd:

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -22,8 +22,8 @@ def patch_buildozer_file_exists():
     return patch_buildozer("file_exists")
 
 
-def patch_buildozer_error():
-    return patch_buildozer("error")
+def patch_logger_error():
+    return mock.patch("buildozer.logger.Logger.error")
 
 
 def default_specfile_path():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,53 @@
+import unittest
+from buildozer.logger import Logger
+
+from io import StringIO
+from unittest import mock
+
+
+class TestLogger(unittest.TestCase):
+    def test_log_print(self):
+        """
+        Checks logger prints different info depending on log level.
+        """
+        logger = Logger()
+
+        # Test ERROR Level
+        Logger.set_level(0)
+        assert logger.log_level == logger.ERROR
+
+        # at this level, only error messages should be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        # using `in` keyword rather than `==` because of color prefix/suffix
+        assert "debug message" not in mock_stdout.getvalue()
+        assert "info message" not in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()
+
+        # Test INFO Level
+        Logger.set_level(1)
+        assert logger.log_level == logger.INFO
+
+        # at this level, debug messages should not be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        # using `in` keyword rather than `==` because of color prefix/suffix
+        assert "debug message" not in mock_stdout.getvalue()
+        assert "info message" in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()
+
+        # sets log level to 2 in the spec file
+        Logger.set_level(2)
+        assert logger.log_level == logger.DEBUG
+        # at this level all message types should be printed
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger.debug("debug message")
+            logger.info("info message")
+            logger.error("error message")
+        assert "debug message" in mock_stdout.getvalue()
+        assert "info message" in mock_stdout.getvalue()
+        assert "error message" in mock_stdout.getvalue()


### PR DESCRIPTION
First step toward #1629.

Code related to logging moved into its own class/file.
References (including in targets and tests) updated.
Unit tests separated out, and enhanced to test more conditions.
Trivial indenting/grammar issues in osx.py fixed.
No-op exception handling code removed.