### PR TITLE
Remove `python2` test as `python2` is not available anymore via `actions/setup-python`

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -45,18 +45,3 @@ jobs:
       run: docker build --tag=kivy/buildozer .
     - name: Docker run
       run: docker run kivy/buildozer --version
-
-  Python2:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-    - uses: actions/checkout@v2
-    - name: Try Python 2 install
-      run: |
-        # we don't want the build to fail with the exit 1 so we catch with "||"
-        python2 -m pip install -e . 2> error.log || echo Failing as expected
-        cat error.log
-        grep "Unsupported Python version" error.log


### PR DESCRIPTION
This test was only meant to make sure that we show the "not compatible with python2" error.
More testing is generally great, but unfortunately `python2` is not available anymore via `setup-python` and the pipeline is now failing.

If we want to keep the test up and running, we need to do that in another way, but it will increase the complexity of our CI.