### PR TITLE
Use a pinned version of `Cython` for now, as most of the recipes are incompatible with `Cython==3.x.x`

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup environment
       run: |
         pip install -e .
-        pip install Cython
+        pip install Cython==0.29.36
     - run: buildozer --help
     - run: buildozer init
     - name: SDK, NDK and p4a download

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
         pip install -e .
-        pip install Cython cookiecutter pbxproj
+        pip install Cython==0.29.36 cookiecutter pbxproj
     - name: Check buildozer installation
       run: |
         source .ci/osx_ci.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ WORKDIR ${WORK_DIR}
 COPY --chown=user:user . ${SRC_DIR}
 
 # installs buildozer and dependencies
-RUN pip3 install --user --upgrade Cython==0.29.33 wheel pip virtualenv ${SRC_DIR}
+RUN pip3 install --user --upgrade Cython==0.29.36 wheel pip virtualenv ${SRC_DIR}
 
 ENTRYPOINT ["buildozer"]


### PR DESCRIPTION
`Cython>=3.0.0` broke our CI pipeline.

But it's not `Cython` fault, instead, we urge to change our `python-for-android` and `kivy-ios` logic to not rely on a single specific `Cython` version for all the packages, as every package should be able to decide the `Cython` (and other build-time-only packages to use).

Meanwhile, to keep the development up and running, that seems the faster solution.

