### PR TITLE
Separate ConfigSpec parser (Address #1636)

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -415,48 +415,11 @@ warn_on_root = 1
 # (str) Path to build output (i.e. .apk, .aab, .ipa) storage
 # bin_dir = ./bin
 
-#    -----------------------------------------------------------------------------
-#    List as sections
-#
-#    You can define all the "list" as [section:key].
-#    Each line will be considered as a option to the list.
-#    Let's take [app] / source.exclude_patterns.
-#    Instead of doing:
-#
-#[app]
-#source.exclude_patterns = license,data/audio/*.wav,data/images/original/*
-#
-#    This can be translated into:
-#
-#[app:source.exclude_patterns]
-#license
-#data/audio/*.wav
-#data/images/original/*
-#
-
-
-#    -----------------------------------------------------------------------------
-#    Profiles
-#
-#    You can extend section / key with a profile
-#    For example, you want to deploy a demo version of your application without
-#    HD content. You could first change the title to add "(demo)" in the name
-#    and extend the excluded directories to remove the HD content.
-#
-#[app@demo]
-#title = My Application (demo)
-#
-#[app:source.exclude_patterns@demo]
-#images/hd/*
-#
-#    Then, invoke the command line with the "demo" profile:
-#
-#buildozer --profile demo android debug
-
-### Notes about using this file: ###
+#-----------------------------------------------------------------------------
+#   Notes about using this file:
 #
 #   Buildozer uses a variant of Python's ConfigSpec to read this file.
-#   For the syntax, including interpolations, see
+#   For the basic syntax, including interpolations, see
 #       https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
 #
 #   Warning: Comments cannot be used "inline" - i.e.
@@ -486,3 +449,20 @@ warn_on_root = 1
 #   Buildozer supports overriding options through environment variables.
 #   Name an environment variable as SECTION_OPTION to override a value in a .spec
 #   file.
+#
+#   Buildozer support overriding options through profiles.
+#   For example, you want to deploy a demo version of your application without
+#   HD content. You could first change the title to add "(demo)" in the name
+#   and extend the excluded directories to remove the HD content.
+#
+#       [app@demo]
+#       title = My Application (demo)
+#
+#       [app:source.exclude_patterns@demo]
+#       images/hd/*
+#
+#   Then, invoke the command line with the "demo" profile:
+#
+#        buildozer --profile demo android debug
+#
+#   Environment variable overrides have priority over profile overrides.

--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -1,3 +1,8 @@
+# This .spec config file tells Buildozer an app's requirements for being built.
+#
+# It largely follows the syntax of an .ini file.
+# See the end of the file for more details and warnings about common mistakes.
+
 [app]
 
 # (str) Title of your application
@@ -447,3 +452,37 @@ warn_on_root = 1
 #    Then, invoke the command line with the "demo" profile:
 #
 #buildozer --profile demo android debug
+
+### Notes about using this file: ###
+#
+#   Buildozer uses a variant of Python's ConfigSpec to read this file.
+#   For the syntax, including interpolations, see
+#       https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+#
+#   Warning: Comments cannot be used "inline" - i.e.
+#       [app]
+#       title = My Application # This is not a comment, it is part of the title.
+#
+#   Warning: Indented text is treated as a multiline string - i.e.
+#       [app]
+#       title = My Application
+#          package.name = myapp # This is all part of the title.
+#
+#   Buildozer's .spec files have some additional features:
+#
+#   Buildozer supports lists - i.e.
+#       [app]
+#       source.include_exts = py,png,jpg
+#       #                     ^ This is a list.
+#
+#       [app:source.include_exts]
+#       py
+#       png
+#       jpg
+#       # ^ This is an alternative syntax for a list.
+#
+#   Buildozer's option names are case-sensitive, unlike most .ini files.
+#
+#   Buildozer supports overriding options through environment variables.
+#   Name an environment variable as SECTION_OPTION to override a value in a .spec
+#   file.

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -36,6 +36,8 @@ except ImportError:
 
 class BuildozerRemote(Buildozer):
     def run_command(self, args):
+        profile = None
+
         while args:
             if not args[0].startswith('-'):
                 break
@@ -45,7 +47,7 @@ class BuildozerRemote(Buildozer):
                 self.logger.log_level = 2
 
             elif arg in ('-p', '--profile'):
-                self.config_profile = args.pop(0)
+                profile = args.pop(0)
 
             elif arg in ('-h', '--help'):
                 self.usage()
@@ -55,7 +57,7 @@ class BuildozerRemote(Buildozer):
                 print('Buildozer (remote) {0}'.format(__version__))
                 exit(0)
 
-        self._merge_config_profile()
+        self.config.apply_profile(profile)
 
         if len(args) < 2:
             self.usage()

--- a/buildozer/specparser.py
+++ b/buildozer/specparser.py
@@ -1,0 +1,128 @@
+"""
+    A customised ConfigParser, suitable for buildozer.spec.
+
+    Supports
+        - list values
+            - either comma separated, or in their own [section:option] section.
+        - environment variable overrides of values
+            - overrides applied at construction.
+        - case-sensitive keys
+        - "No values" are permitted.
+"""
+
+from configparser import ConfigParser
+from os import environ
+
+
+class SpecParser(ConfigParser):
+    def __init__(self, *args, **kwargs):
+        # Allow "no value" options to better support lists.
+        super().__init__(*args, allow_no_value=True, **kwargs)
+
+    def optionxform(self, optionstr: str) -> str:
+        """Override method that canonicalizes keys to retain
+        case sensitivity."""
+        return optionstr
+
+    # Override all the readers to apply env variables over the top.
+
+    def read(self, filenames, encoding=None):
+        super().read(filenames, encoding)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_file(self, f, source=None):
+        super().read_file(f, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_string(self, string, source="<string>"):
+        super().read_string(string, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    def read_dict(self, dictionary, source="<dict>"):
+        super().read_dict(dictionary, source)
+        # Let environment variables override the values
+        self._override_config_from_envs()
+
+    # Add new getters
+
+    def getlist(
+        self, section, token, default=None, with_values=False, strip=True,
+        section_sep="=", split_char=","
+    ):
+        """Return a list of strings.
+
+        They can be found as the list of options in a [section:token] section,
+        or in a [section], under the a option, as a comma-separated (or
+        split_char-separated) list,
+        Failing that, default is returned (as is).
+
+        If with_values is set, and they are in a [section:token] section,
+        the option values are included with the option key,
+        separated by section_sep
+        """
+
+        # if a section:token is defined, let's use the content as a list.
+        l_section = "{}:{}".format(section, token)
+        if self.has_section(l_section):
+            values = self.options(l_section)
+            if with_values:
+                return [
+                    "{}{}{}".format(key, section_sep, self.get(l_section, key))
+                    for key in values
+                ]
+            return values if not strip else [x.strip() for x in values]
+        values = self.getdefault(section, token, None)
+        if values is None:
+            return default
+        values = values.split(split_char)
+        if not values:
+            return default
+        return values if not strip else [x.strip() for x in values]
+
+    def getlistvalues(self, section, token, default=None):
+        """ Convenience function.
+            Deprecated - call getlist directly."""
+        return self.getlist(section, token, default, with_values=True)
+
+    def getdefault(self, section, token, default=None):
+        """
+        Convenience function.
+        Deprecated - call get directly."""
+        return self.get(section, token, fallback=default)
+
+    def getbooldefault(self, section, token, default=False):
+        """
+        Convenience function.
+        Deprecated - call getboolean directly."""
+        return self.getboolean(section, token, fallback=default)
+
+    # Handle env vars.
+
+    def _override_config_from_envs(self):
+        """Takes a ConfigParser, and checks every section/token for an
+        environment variable of the form SECTION_TOKEN, with any dots
+        replaced by underscores. If the variable exists, sets the config
+        variable to the env value.
+        """
+        for section in self.sections():
+            for token in self.options(section):
+                self._override_config_token_from_env(section, token)
+
+    def _override_config_token_from_env(self, section, token):
+        """Given a config section and token, checks for an appropriate
+        environment variable. If the variable exists, sets the config entry to
+        its value.
+
+        The environment variable checked is of the form SECTION_TOKEN, all
+        upper case, with any dots replaced by underscores.
+
+        """
+        env_var_name = "_".join(
+            item.upper().replace(".", "_") for item in (section, token)
+        )
+        env_var = environ.get(env_var_name)
+        if env_var is not None:
+            self.set(section, token, env_var)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -1432,8 +1432,12 @@ class TargetAndroid(Target):
         serial = self.serials[0:]
         if not serial:
             return
-        filters = self.buildozer.config.getrawdefault(
-            "app", "android.logcat_filters", "", section_sep=":", split_char=" ")
+        filters = self.buildozer.config.getlist(
+            "app",
+            "android.logcat_filters",
+            default="",
+            section_sep=":",
+            strip=False)
         filters = " ".join(filters)
         self.buildozer.environ['ANDROID_SERIAL'] = serial[0]
         extra_args = []

--- a/tests/test_specparser.py
+++ b/tests/test_specparser.py
@@ -1,0 +1,172 @@
+from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from buildozer.specparser import SpecParser
+
+
+class TestSpecParser(unittest.TestCase):
+    def test_overrides(self):
+        environ["SECTION_1_ATTRIBUTE_1"] = "Env Value"
+
+        # Test as a string.
+        sp = SpecParser()
+        sp.read_string(
+            """
+            [section.1]
+            attribute.1=String Value
+            """
+        )
+        assert sp.get("section.1", "attribute.1") == "Env Value"
+
+        # Test as a dict
+        sp = SpecParser()
+        sp.read_dict({"section.1": {"attribute.1": "Dict Value"}})
+        assert sp.get("section.1", "attribute.1") == "Env Value"
+
+        with TemporaryDirectory() as temp_dir:
+            spec_path = Path(temp_dir) / "test.spec"
+            with open(spec_path, "w") as spec_file:
+                spec_file.write(
+                    """
+                    [section.1]
+                    attribute.1=File Value
+                    """
+                )
+
+            # Test as a file
+            sp = SpecParser()
+            with open(spec_path, "r") as spec_file:
+                sp.read_file(spec_file)
+            assert sp.get("section.1", "attribute.1") == "Env Value"
+
+            # Test as a list of filenames
+            sp = SpecParser()
+            sp.read([spec_path])
+            assert sp.get("section.1", "attribute.1") == "Env Value"
+
+    def test_new_getters(self):
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section1]
+                attribute1=1
+                attribute2=red, white, blue
+                attribute3=True
+                attribute5=large/medium/small
+
+                [section2:attribute4]
+                red=1
+                amber=
+                green=3
+
+
+            """
+        )
+
+        assert sp.get("section1", "attribute1") == "1"
+        assert sp.getlist("section1", "attribute2") == ["red", "white", "blue"]
+        assert sp.getlist("section1", "attribute2", strip=False) == [
+            "red",
+            " white",
+            " blue",
+        ]
+
+        assert sp.getlist("section2", "attribute4") == [
+            "red",
+            "amber",
+            "green",
+        ]
+        # Test with_values and section_sep
+        assert sp.getlistvalues("section2", "attribute4") == [
+            "red=1",
+            "amber=",
+            "green=3",
+        ]
+        assert sp.getlist(
+            "section2", "attribute4", with_values=True, section_sep=":"
+        ) == [
+            "red:1",
+            "amber:",
+            "green:3",
+        ]
+        # Test split_char
+        assert sp.getlist("section1", "attribute5", with_values=True) == [
+            "large/medium/small",
+        ]
+        assert sp.getlist(
+            "section1", "attribute5", with_values=True, split_char="/"
+        ) == [
+            "large",
+            "medium",
+            "small",
+        ]
+
+        assert sp.getbooldefault("section1", "attribute3") is True
+
+    def test_case_sensitivity(self):
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section1]
+                attribute1=a
+                Attribute1=A
+            """
+        )
+
+        assert sp.get("section1", "attribute1") == "a"
+        assert sp.get("section1", "Attribute1") == "A"
+
+    def test_controversial_cases(self):
+        """Some aspects of the config syntax seem to cause confusion.
+        This shows what the code is *specified* to do, which might not be
+        expected.
+        """
+        sp = SpecParser()
+        sp.read_string(
+            """
+                [section]
+                    # Comments can be indented.
+                option1=a  # This is not considered a comment
+                option2=this is
+                   a multiline string (not a list!)
+                   # This is considered a comment.
+                   this_is_not_an_option=it is still part of the multiline
+                option3=this, is, one, way, of, representing, lists
+
+                [section:option4]
+                this_is
+                another_way
+                # This is a comment.
+                of # This is not a comment.
+                representing=4
+                lists
+            """
+        )
+
+        assert (
+            sp.get("section", "option1") ==
+            "a  # This is not considered a comment"
+        )
+        assert (
+            sp.get("section", "option2") ==
+            "this is\na multiline string (not a list!)\n"
+            "this_is_not_an_option=it is still part of the multiline"
+        )
+        assert sp.getlist("section", "option3") == [
+            "this",
+            "is",
+            "one",
+            "way",
+            "of",
+            "representing",
+            "lists",
+        ]
+        assert sp.getlist("section", "option4") == [
+            "this_is",
+            "another_way",
+            "of # This is not a comment.",
+            "representing",
+            "lists",
+        ]


### PR DESCRIPTION
Separate ConfigParser code from Buildozer.

- Use subclass, rather than monkey-patching.
- Single implementation of list-handling code.
- Convenience functions to minimise impact of existing code (but instantly deprecated).
- Treat defaults consistently
- Apply the env overrides automatically (client doesn't need to trigger).
- Apply the env overrides once (read-time) rather than on every get.
- Avoid re-using term "raw" which has pre-existing definition in ConfigSpec.
   - Update android.py client to match,
- Unit tests.

Add comments to start and end of default.spec to explain the syntax (as discussed in #1636)