### PR TITLE
Update Python version support

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -6,7 +6,6 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.7'
            - '3.8'
            - '3.9'
            - '3.10'

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-Buildozer is tested on Python 3.7 and above but may work on
+Buildozer is tested on Python 3.8 and above but may work on
 earlier versions, back to Python 3.3.
 Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,7 +2,8 @@
 Installation
 ============
 
-Buildozer itself doesn't depend on any library Python >= 3.3.
+Buildozer is tested on Python 3.7 and above but may work on
+earlier versions, back to Python 3.3.
 Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for
 you, but it doesn't cover every situation.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import io
 here = os.path.abspath(os.path.dirname(__file__))
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 6)
+REQUIRED_PYTHON = (3, 8)
 
 # This check and everything above must remain compatible with Python 2.7.
 if CURRENT_PYTHON < REQUIRED_PYTHON:
@@ -70,9 +70,11 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Stop testing on Python 3.7 (end of life)
Explain more clearly in documentation what versions are supported. 
Update list of classifiers.