### PR TITLE
Minor Win32 improvements

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -244,11 +244,13 @@ class TargetAndroid(Target):
 
     @property
     def sdkmanager_path(self):
-        sdkmanager_path = join(
-            self.android_sdk_dir, 'tools', 'bin',
+        sdk_manager_name = (
             'sdkmanager.bat'
             if platform in ('win32', 'cygwin')
-            else 'sdkmanager')
+            else 'sdkmanager'
+        )
+        sdkmanager_path = join(
+            self.android_sdk_dir, 'tools', 'bin', sdk_manager_name)
         if not os.path.isfile(sdkmanager_path):
             raise BuildozerException(
                 ('sdkmanager path "{}" does not exist, sdkmanager is not'


### PR DESCRIPTION
There is no win32 support for the Android target. This doesn't change that. It does, however, enable experimental support, via an (unpublished) environment variable, to allow exploration of what is required.

Also, there are some signs of vestigial attempts at supporting Windows. As they haven't been run before, they need a little care:

- Updated references from _winreg to winreg (Built-in module was renamed in Python 3.)
- Corrected download URL to Android NDK for the Windows platform
- Supported sdkmanager installer having a different name (.bat extension) on Windows.

- Also corrected trivial formatting error in Exception text, which applies to all platforms.