### PR TITLE
Move Exception declarations into own file

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -34,6 +34,7 @@ except ImportError:
     # on windows, no fcntl
     fcntl = None
 
+from buildozer.exceptions import BuildozerCommandException
 from buildozer.jsonstore import JsonStore
 from buildozer.logger import Logger
 from buildozer.specparser import SpecParser
@@ -48,22 +49,6 @@ class ChromeDownloader(FancyURLopener):
 
 
 urlretrieve = ChromeDownloader().retrieve
-
-
-class BuildozerException(Exception):
-    '''
-    Exception raised for general situations buildozer cannot process.
-    '''
-    pass
-
-
-class BuildozerCommandException(BuildozerException):
-    '''
-    Exception raised when an external command failed.
-
-    See: `Buildozer.cmd()`.
-    '''
-    pass
 
 
 class Buildozer:

--- a/buildozer/scripts/client.py
+++ b/buildozer/scripts/client.py
@@ -5,7 +5,9 @@ Main Buildozer client
 '''
 
 import sys
-from buildozer import Buildozer, BuildozerCommandException, BuildozerException
+
+from buildozer import Buildozer
+from buildozer.exceptions import BuildozerCommandException, BuildozerException
 from buildozer.logger import Logger
 
 

--- a/buildozer/scripts/remote.py
+++ b/buildozer/scripts/remote.py
@@ -13,25 +13,27 @@ You need paramiko to make it work.
 
 __all__ = ["BuildozerRemote"]
 
-import socket
-import sys
-from buildozer import (
-    Buildozer, BuildozerCommandException, BuildozerException, __version__)
-from buildozer.logger import Logger
-from sys import stdout, stdin, exit
-from select import select
-from os.path import join, expanduser, realpath, exists, splitext
-from os import makedirs, walk, getcwd
 from configparser import ConfigParser
+from os import makedirs, walk, getcwd
+from os.path import join, expanduser, realpath, exists, splitext
+import socket
+from select import select
+import sys
+from sys import stdout, stdin, exit
 try:
     import termios
     has_termios = True
 except ImportError:
     has_termios = False
+
 try:
     import paramiko
 except ImportError:
     print('Paramiko missing: pip install paramiko')
+
+from buildozer import Buildozer, __version__
+from buildozer.exceptions import BuildozerCommandException, BuildozerException
+from buildozer.logger import Logger
 
 
 class BuildozerRemote(Buildozer):

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -20,25 +20,27 @@ APACHE_ANT_VERSION = '1.9.4'
 # doesn't support any newer NDK.
 DEFAULT_ANDROID_NDK_VERSION = '17c'
 
-import traceback
-import io
-import re
 import ast
-from sys import platform, executable
-from buildozer import BuildozerException
-from buildozer.logger import USE_COLOR
-from buildozer.target import Target
+from glob import glob
+import io
 from os import environ
 from os.path import exists, join, realpath, expanduser, basename, relpath
 from platform import architecture
-from shutil import copyfile, rmtree, which
+import re
 import shlex
-import pexpect
-from glob import glob
+from shutil import copyfile, rmtree, which
+from sys import platform, executable
 from time import sleep
+import traceback
 
-from buildozer.libs.version import parse
 from distutils.version import LooseVersion
+import pexpect
+
+from buildozer.exceptions import BuildozerException
+from buildozer.logger import USE_COLOR
+from buildozer.target import Target
+from buildozer.libs.version import parse
+
 
 # buildozer.spec tokens that used to exist but are now ignored
 DEPRECATED_TOKENS = (('app', 'android.sdk'), )

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -2,12 +2,14 @@
 iOS target, based on kivy-ios project
 '''
 
-import sys
-import plistlib
-from buildozer import BuildozerCommandException
-from buildozer.target import Target, no_config
-from os.path import join, basename, expanduser, realpath
+
 from getpass import getpass
+from os.path import join, basename, expanduser, realpath
+import plistlib
+import sys
+
+from buildozer.exceptions import BuildozerCommandException
+from buildozer.target import Target, no_config
 
 
 PHP_TEMPLATE = '''

--- a/tests/scripts/test_client.py
+++ b/tests/scripts/test_client.py
@@ -1,8 +1,9 @@
 import sys
 import unittest
-from buildozer import BuildozerCommandException
-from buildozer.scripts import client
 from unittest import mock
+
+from buildozer.exceptions import BuildozerCommandException
+from buildozer.scripts import client
 
 
 class TestClient(unittest.TestCase):

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from buildozer import BuildozerCommandException
+from buildozer.exceptions import BuildozerCommandException
 from buildozer.targets.ios import TargetIos
 from tests.targets.utils import (
     init_buildozer,


### PR DESCRIPTION
This is a refactor; it adds no new functionality, but is part of a larger effort to move code out of (too large) `buildozer/__init__.py`.

Also made any import lists that were touched pep8-compliant in sort order.