### PR TITLE
Migrate all usages of mkdir and rmdir to buildops

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
     # on windows, no fcntl
     fcntl = None
 
-from buildozer.buildops import mkdir, rmdir
+import buildozer.buildops as buildops
 from buildozer.exceptions import BuildozerCommandException
 from buildozer.jsonstore import JsonStore
 from buildozer.logger import Logger
@@ -362,22 +362,22 @@ class Buildozer:
             exit(1)
 
         # create global dir
-        mkdir(self.global_buildozer_dir)
-        mkdir(self.global_cache_dir)
+        buildops.mkdir(self.global_buildozer_dir)
+        buildops.mkdir(self.global_cache_dir)
 
         # create local .buildozer/ dir
-        mkdir(self.buildozer_dir)
+        buildops.mkdir(self.buildozer_dir)
         # create local bin/ dir
-        mkdir(self.bin_dir)
+        buildops.mkdir(self.bin_dir)
 
-        mkdir(self.applibs_dir)
+        buildops.mkdir(self.applibs_dir)
         self.state = JsonStore(join(self.buildozer_dir, 'state.db'))
 
         target = self.targetname
         if target:
-            mkdir(join(self.global_platform_dir, target, 'platform'))
-            mkdir(join(self.buildozer_dir, target, 'platform'))
-            mkdir(join(self.buildozer_dir, target, 'app'))
+            buildops.mkdir(join(self.global_platform_dir, target, 'platform'))
+            buildops.mkdir(join(self.buildozer_dir, target, 'platform'))
+            buildops.mkdir(join(self.buildozer_dir, target, 'app'))
 
     def check_application_requirements(self):
         '''Ensure the application requirements are all available and ready to be
@@ -411,8 +411,8 @@ class Buildozer:
             return
 
         # recreate applibs
-        rmdir(self.applibs_dir)
-        mkdir(self.applibs_dir)
+        buildops.rmdir(self.applibs_dir)
+        buildops.mkdir(self.applibs_dir)
 
         # ok now check the availability of all requirements
         for requirement in requirements:
@@ -689,7 +689,7 @@ class Buildozer:
 
                 # ensure the directory exists
                 dfn = dirname(rfn)
-                mkdir(dfn)
+                buildops.mkdir(dfn)
 
                 # copy!
                 self.logger.debug('Copy {0}'.format(sfn))

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -2,6 +2,7 @@ from sys import exit
 import os
 from os.path import join
 
+from buildozer.buildops import mkdir
 from buildozer.logger import Logger
 
 
@@ -253,7 +254,7 @@ class Target:
         custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, **kwargs)
         if not self.buildozer.file_exists(install_dir):
             if custom_dir:
-                cmd(["mkdir", "-p", install_dir])
+                mkdir(install_dir)
                 cmd(["cp", "-a", f"{custom_dir}/*", f"{install_dir}/"])
             else:
                 cmd(["git", "clone", "--branch", clone_branch, clone_url], cwd=self.buildozer.platform_dir)

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -2,7 +2,7 @@ from sys import exit
 import os
 from os.path import join
 
-from buildozer.buildops import mkdir
+import buildozer.buildops as buildops
 from buildozer.logger import Logger
 
 
@@ -254,7 +254,7 @@ class Target:
         custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, **kwargs)
         if not self.buildozer.file_exists(install_dir):
             if custom_dir:
-                mkdir(install_dir)
+                buildops.mkdir(install_dir)
                 cmd(["cp", "-a", f"{custom_dir}/*", f"{install_dir}/"])
             else:
                 cmd(["git", "clone", "--branch", clone_branch, clone_url], cwd=self.buildozer.platform_dir)

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -8,6 +8,7 @@ from os.path import join, basename, expanduser, realpath
 import plistlib
 import sys
 
+from buildozer.buildops import rmdir
 from buildozer.exceptions import BuildozerCommandException
 from buildozer.target import Target, no_config
 
@@ -270,7 +271,7 @@ class TargetIos(Target):
         ipa = join(self.buildozer.bin_dir, ipa_name)
         build_dir = join(self.ios_dir, '{}-ios'.format(app_name.lower()))
 
-        self.buildozer.rmdir(intermediate_dir)
+        rmdir(intermediate_dir)
 
         self.logger.info('Creating archive...')
         self.xcodebuild(

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -8,7 +8,7 @@ from os.path import join, basename, expanduser, realpath
 import plistlib
 import sys
 
-from buildozer.buildops import rmdir
+import buildozer.buildops as buildops
 from buildozer.exceptions import BuildozerCommandException
 from buildozer.target import Target, no_config
 
@@ -271,7 +271,7 @@ class TargetIos(Target):
         ipa = join(self.buildozer.bin_dir, ipa_name)
         build_dir = join(self.ios_dir, '{}-ios'.format(app_name.lower()))
 
-        rmdir(intermediate_dir)
+        buildops.rmdir(intermediate_dir)
 
         self.logger.info('Creating archive...')
         self.xcodebuild(


### PR DESCRIPTION
This is a refactor as one step to reduce the size/complexity of the Buildozer class. It doesn't change functionality. except to improve logging consistency and a small performance improvement

* mkdir() and rmdir() methods removed from `buildozer/__init__.py` (cleaner versions are already in `buildops.py`)
* All references to buildozer's mkdir and rmdir changed over to use buildops.
* Call to Linux's mkdir via a separate shell replaced with (faster, and platform independent) library call.
* Re-ordered imports, where touched, to match PEP8.