### PR TITLE
Migrate to use Buildop's rmtree, file_copy, file_copytree and rename

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -255,12 +255,12 @@ class Target:
         if not self.buildozer.file_exists(install_dir):
             if custom_dir:
                 buildops.mkdir(install_dir)
-                cmd(["cp", "-a", f"{custom_dir}/*", f"{install_dir}/"])
+                buildops.file_copytree(custom_dir, install_dir)
             else:
                 cmd(["git", "clone", "--branch", clone_branch, clone_url], cwd=self.buildozer.platform_dir)
         elif self.platform_update:
             if custom_dir:
-                cmd(["cp", "-a", f"{custom_dir}/*", f"{install_dir}/"])
+                buildops.file_copytree(custom_dir, install_dir)
             else:
                 cmd(["git", "clean", "-dxf"], cwd=install_dir)
                 cmd(["git", "pull", "origin", clone_branch], cwd=install_dir)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -28,7 +28,7 @@ from os.path import exists, join, realpath, expanduser, basename, relpath
 from platform import architecture
 import re
 import shlex
-from shutil import copyfile, rmtree, which
+from shutil import which
 from sys import platform, executable
 from time import sleep
 import traceback
@@ -36,6 +36,7 @@ import traceback
 from distutils.version import LooseVersion
 import pexpect
 
+import buildozer.buildops as buildops
 from buildozer.exceptions import BuildozerException
 from buildozer.logger import USE_COLOR
 from buildozer.target import Target
@@ -450,9 +451,10 @@ class TargetAndroid(Target):
         self.logger.info('Unpacking Android NDK')
         self.buildozer.file_extract(archive,
                                     cwd=self.buildozer.global_platform_dir)
-        self.buildozer.file_rename(unpacked,
-                                   ndk_dir,
-                                   cwd=self.buildozer.global_platform_dir)
+        buildops.rename(
+            unpacked,
+            ndk_dir,
+            cwd=self.buildozer.global_platform_dir)
         self.logger.info('Android NDK installation done.')
         return ndk_dir
 
@@ -681,7 +683,7 @@ class TargetAndroid(Target):
                     self.logger.info(
                         f"Detected old url/branch ({cur_url}/{cur_branch}), deleting..."
                     )
-                    rmtree(p4a_dir)
+                    buildops.rmdir(p4a_dir)
 
             if not self.buildozer.file_exists(p4a_dir):
                 cmd(
@@ -1052,7 +1054,7 @@ class TargetAndroid(Target):
 
             self.logger.debug('Search and copy libs for {}'.format(lib_dir))
             for fn in self.buildozer.file_matches(patterns):
-                self.buildozer.file_copy(
+                buildops.file_copy(
                     join(self.buildozer.root_dir, fn),
                     join(dist_dir, 'libs', lib_dir, basename(fn)))
 
@@ -1289,7 +1291,9 @@ class TargetAndroid(Target):
             arch=self.archs_snake, artifact_format=self.artifact_format)
 
         # copy to our place
-        copyfile(join(artifact_dir, artifact), join(self.buildozer.bin_dir, artifact_dest))
+        buildops.file_copy(
+            join(artifact_dir, artifact),
+            join(self.buildozer.bin_dir, artifact_dest))
 
         self.logger.info('Android packaging done!')
         self.logger.info(

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -310,7 +310,7 @@ class TargetIos(Target):
             cwd=build_dir)
 
         self.logger.info('Moving IPA to bin...')
-        self.buildozer.file_rename(ipa_tmp, ipa)
+        buildops.file_rename(ipa_tmp, ipa)
 
         self.logger.info('iOS packaging done!')
         self.logger.info('IPA {0} available in the bin directory'.format(

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -65,7 +65,7 @@ def call_build_package(target_android):
     with patch_target_android('_update_libraries_references') as m_update_libraries_references, \
          patch_target_android('_generate_whitelist') as m_generate_whitelist, \
          mock.patch('buildozer.targets.android.TargetAndroid.execute_build_package') as m_execute_build_package, \
-         mock.patch('buildozer.targets.android.copyfile') as m_copyfile, \
+         mock.patch('buildozer.targets.android.buildops.file_copy') as m_copyfile, \
          mock.patch('buildozer.targets.android.os.listdir') as m_listdir:
         m_listdir.return_value = ['30.0.0-rc2']
         target_android.build_package()


### PR DESCRIPTION
This is part of a bigger refactor to reduce the size and complexity of the Buildozer class. It adds no new functionality (apart from making logging more consistent)

* Remove file_rename, file_copy and file_copytree from Buildozer.
* Update all references to those Buildozer methods to refer to buildops equivalents.
   * Note: `file_rename` is now called rename as, in practice, it was also used to rename directories.
* Updated all references to shutil.copyfile and shutil.rmtree to use the Buildops equivalents
  * Note this adds implicit debug logging, making them more consistent.
* Updated all references to check_call() and check_output() that called the `rm` and `cp` shell commands.
  * Note this adds implicit debug logging, making them more consistent, and improves performance.
* Updated mock in test.

Cheekily, also removed some obsolete references to Python 2 (only) standard libraries to make my IDE stop warning me about them while I edited the file.