### PR TITLE
Use buildops for file_exists and file_matches

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -66,7 +66,7 @@ class Buildozer:
 
         self.logger = Logger()
 
-        if exists(filename):
+        if buildops.file_exists(filename):
             self.config.read(filename, "utf-8")
             self.check_configuration_tokens()
 
@@ -356,7 +356,7 @@ class Buildozer:
         '''
         self.logger.info('Ensure build layout')
 
-        if not exists(self.specfilename):
+        if not buildops.file_exists(self.specfilename):
             print('No {0} found in the current directory. Abandon.'.format(
                 self.specfilename))
             exit(1)
@@ -440,7 +440,7 @@ class Buildozer:
         if hasattr(self, 'venv'):
             return
         self.venv = join(self.buildozer_dir, 'venv')
-        if not self.file_exists(self.venv):
+        if not buildops.file_exists(self.venv):
             self.cmd(["python3", "-m", "venv", "./venv"],
                     cwd=self.buildozer_dir)
 
@@ -464,17 +464,6 @@ class Buildozer:
         # ensure any sort of compilation will fail
         self.env_venv['CC'] = '/bin/false'
         self.env_venv['CXX'] = '/bin/false'
-
-    def file_matches(self, patterns):
-        from glob import glob
-        result = []
-        for pattern in patterns:
-            matches = glob(expanduser(pattern.strip()))
-            result.extend(matches)
-        return result
-
-    def file_exists(self, *args):
-        return exists(join(*args))
 
     def file_extract(self, archive, cwd=None):
         if archive.endswith('.tgz') or archive.endswith('.tar.gz'):
@@ -518,7 +507,7 @@ class Buildozer:
         url = url + filename
         if cwd:
             filename = join(cwd, filename)
-        if self.file_exists(filename):
+        if buildops.file_exists(filename):
             unlink(filename)
 
         self.logger.debug('Downloading {0}'.format(url))
@@ -674,7 +663,7 @@ class Buildozer:
                 join(self.app_dir, 'sitecustomize.py'))
 
         main_py = join(self.app_dir, 'service', 'main.py')
-        if not self.file_exists(main_py):
+        if not buildops.file_exists(main_py):
             return
 
         header = (b'import sys, os; '

--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -252,7 +252,7 @@ class Target:
         cmd = self.buildozer.cmd
         install_dir = join(self.buildozer.platform_dir, repo)
         custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, **kwargs)
-        if not self.buildozer.file_exists(install_dir):
+        if not buildops.file_exists(install_dir):
             if custom_dir:
                 buildops.mkdir(install_dir)
                 buildops.file_copytree(custom_dir, install_dir)

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -283,7 +283,7 @@ class TargetAndroid(Target):
             # Check for C header <zlib.h>.
             is_debian_like = which("dpkg") is not None
             if is_debian_like and \
-                    not self.buildozer.file_exists('/usr/include/zlib.h'):
+                    not buildops.file_exists('/usr/include/zlib.h'):
                 raise BuildozerException(
                     'zlib headers must be installed, '
                     'run: sudo apt-get install zlib1g-dev')
@@ -344,7 +344,7 @@ class TargetAndroid(Target):
 
     def _install_apache_ant(self):
         ant_dir = self.apache_ant_dir
-        if self.buildozer.file_exists(ant_dir):
+        if buildops.file_exists(ant_dir):
             self.logger.info('Apache ANT found at {0}'.format(ant_dir))
             return ant_dir
 
@@ -364,7 +364,7 @@ class TargetAndroid(Target):
 
     def _install_android_sdk(self):
         sdk_dir = self.android_sdk_dir
-        if self.buildozer.file_exists(sdk_dir):
+        if buildops.file_exists(sdk_dir):
             self.logger.info('Android SDK found at {0}'.format(sdk_dir))
             return sdk_dir
 
@@ -396,7 +396,7 @@ class TargetAndroid(Target):
 
     def _install_android_ndk(self):
         ndk_dir = self.android_ndk_dir
-        if self.buildozer.file_exists(ndk_dir):
+        if buildops.file_exists(ndk_dir):
             self.logger.info('Android NDK found at {0}'.format(ndk_dir))
             return ndk_dir
 
@@ -579,7 +579,7 @@ class TargetAndroid(Target):
         # 3. finally, install the android for the current api
         self.logger.info('Downloading platform api target if necessary')
         android_platform = join(self.android_sdk_dir, 'platforms', 'android-{}'.format(self.android_api))
-        if not self.buildozer.file_exists(android_platform):
+        if not buildops.file_exists(android_platform):
             if not skip_upd:
                 self._sdkmanager(f"platforms;android-{self.android_api}")
             else:
@@ -663,14 +663,14 @@ class TargetAndroid(Target):
                                                           'p4a.source_dir')
         if system_p4a_dir:
             # Don't install anything, just check that the dir does exist
-            if not self.buildozer.file_exists(p4a_dir):
+            if not buildops.file_exists(p4a_dir):
                 self.logger.error(
                     'Path for p4a.source_dir does not exist')
                 self.logger.error('')
                 raise BuildozerException()
         else:
             # check that url/branch has not been changed
-            if self.buildozer.file_exists(p4a_dir):
+            if buildops.file_exists(p4a_dir):
                 cur_url = cmd(
                     ["git", "config", "--get", "remote.origin.url"],
                     get_stdout=True,
@@ -685,7 +685,7 @@ class TargetAndroid(Target):
                     )
                     buildops.rmdir(p4a_dir)
 
-            if not self.buildozer.file_exists(p4a_dir):
+            if not buildops.file_exists(p4a_dir):
                 cmd(
                     [
                         "git",
@@ -1053,7 +1053,7 @@ class TargetAndroid(Target):
                 continue
 
             self.logger.debug('Search and copy libs for {}'.format(lib_dir))
-            for fn in self.buildozer.file_matches(patterns):
+            for fn in buildops.file_matches(patterns):
                 buildops.file_copy(
                     join(self.buildozer.root_dir, fn),
                     join(dist_dir, 'libs', lib_dir, basename(fn)))
@@ -1305,7 +1305,7 @@ class TargetAndroid(Target):
         # ensure the project.properties exist
         project_fn = join(dist_dir, 'project.properties')
 
-        if not self.buildozer.file_exists(project_fn):
+        if not buildops.file_exists(project_fn):
             content = [
                 'target=android-{}\n'.format(self.android_api),
                 'APP_PLATFORM={}\n'.format(self.android_minapi)]
@@ -1328,7 +1328,7 @@ class TargetAndroid(Target):
         for cref in app_references:
             # get the full path of the current reference
             ref = realpath(join(source_dir, cref))
-            if not self.buildozer.file_exists(ref):
+            if not buildops.file_exists(ref):
                 self.logger.error(
                     'Invalid library reference (path not found): {}'.format(
                         cref))
@@ -1402,7 +1402,7 @@ class TargetAndroid(Target):
         # search the APK in the bin dir
         apk = state['android:latestapk']
         full_apk = join(self.buildozer.bin_dir, apk)
-        if not self.buildozer.file_exists(full_apk):
+        if not buildops.file_exists(full_apk):
             self.logger.error(
                 'Unable to found the latest APK. Please run "debug" again.')
 

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -180,7 +180,8 @@ class TargetIos(Target):
 
         self.toolchain(["build", *ios_requirements])
 
-        if not self.buildozer.file_exists(self.ios_deploy_dir, 'ios-deploy'):
+        if not buildops.file_exists(
+                join(self.ios_deploy_dir, 'ios-deploy')):
             self.xcodebuild(cwd=self.ios_deploy_dir)
 
         self.buildozer.state['ios.requirements'] = ios_requirements
@@ -207,7 +208,7 @@ class TargetIos(Target):
             frameworks_cmd.append(f"--add-framework={framework}")
 
         self.app_project_dir = join(self.ios_dir, '{0}-ios'.format(app_name.lower()))
-        if not self.buildozer.file_exists(self.app_project_dir):
+        if not buildops.file_exists(self.app_project_dir):
             cmd = ["create", *frameworks_cmd, app_name, self.buildozer.app_dir]
         else:
             cmd = ["update", *frameworks_cmd, f"{app_name}-ios"]
@@ -364,7 +365,7 @@ class TargetIos(Target):
         if not icon:
             return
         icon_fn = join(self.buildozer.app_dir, icon)
-        if not self.buildozer.file_exists(icon_fn):
+        if not buildops.file_exists(icon_fn):
             self.logger.error('Icon {} does not exists'.format(icon_fn))
             return
 
@@ -416,7 +417,7 @@ class TargetIos(Target):
     def _unlock_keychain(self):
         password_file = join(self.buildozer.buildozer_dir, '.ioscodesign')
         password = None
-        if self.buildozer.file_exists(password_file):
+        if buildops.file_exists(password_file):
             with open(password_file) as fd:
                 password = fd.read()
 

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -12,7 +12,7 @@ from tests.targets.utils import (
     patch_buildozer,
     patch_buildozer_checkbin,
     patch_buildozer_cmd,
-    patch_buildozer_file_exists,
+    patch_buildops_file_exists,
 )
 
 
@@ -182,7 +182,7 @@ class TestTargetAndroid:
     def test_install_android_sdk(self, platform):
         """Basic tests for the _install_android_sdk() method."""
         target_android = init_target(self.temp_dir)
-        with patch_buildozer_file_exists() as m_file_exists, patch_buildozer_download() as m_download:
+        with patch_buildops_file_exists() as m_file_exists, patch_buildozer_download() as m_download:
             m_file_exists.return_value = True
             sdk_dir = target_android._install_android_sdk()
         assert m_file_exists.call_args_list == [
@@ -190,7 +190,7 @@ class TestTargetAndroid:
         ]
         assert m_download.call_args_list == []
         assert sdk_dir.endswith(".buildozer/android/platform/android-sdk")
-        with patch_buildozer_file_exists() as m_file_exists, \
+        with patch_buildops_file_exists() as m_file_exists, \
                 patch_buildozer_download() as m_download, \
                 patch_buildozer_file_extract() as m_file_extract, \
                 patch_platform(platform):

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -1,3 +1,4 @@
+import os.path
 import sys
 import tempfile
 from unittest import mock
@@ -10,7 +11,7 @@ from tests.targets.utils import (
     init_buildozer,
     patch_buildozer_checkbin,
     patch_buildozer_cmd,
-    patch_buildozer_file_exists,
+    patch_buildops_file_exists,
     patch_logger_error,
 )
 
@@ -145,7 +146,7 @@ class TestTargetIos:
         # fmt: off
         with patch_target_ios("get_available_packages") as m_get_available_packages, \
              patch_target_ios("toolchain") as m_toolchain, \
-             patch_buildozer_file_exists() as m_file_exists:
+             patch_buildops_file_exists() as m_file_exists:
             m_get_available_packages.return_value = ["hostpython3", "python3"]
             m_file_exists.return_value = True
             target.compile_platform()
@@ -153,7 +154,7 @@ class TestTargetIos:
         assert m_get_available_packages.call_args_list == [mock.call()]
         assert m_toolchain.call_args_list == [mock.call(["build", "python3"])]
         assert m_file_exists.call_args_list == [
-            mock.call(target.ios_deploy_dir, "ios-deploy")
+            mock.call(os.path.join(target.ios_deploy_dir, "ios-deploy"))
         ]
 
     def test_get_package(self):

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -18,8 +18,8 @@ def patch_buildozer_checkbin():
     return patch_buildozer("checkbin")
 
 
-def patch_buildozer_file_exists():
-    return patch_buildozer("file_exists")
+def patch_buildops_file_exists():
+    return mock.patch("buildozer.buildops.file_exists")
 
 
 def patch_logger_error():

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -134,7 +134,7 @@ class TestBuildozer(unittest.TestCase):
         assert download.call_args_list == [
             mock.call("https://archive.apache.org/dist/ant/binaries/", mock.ANY, cwd=my_ant_path)]
         # Mock ant already installed
-        with mock.patch.object(Buildozer, 'file_exists', return_value=True):
+        with mock.patch('buildozer.buildops.file_exists', return_value=True):
             ant_path = target._install_apache_ant()
         assert ant_path == my_ant_path
 


### PR DESCRIPTION
This is part of a larger refactor, to reduce the size and complexity of the Buildozer class.

* Remove `file_matches()` method from the Buildozer class.
* Change the singular reference to it in `android.py` to use the buildops function.
   * This raises the question: Will this be useful to other targets in the future, or should this be moved into the android target? Left for future refactors.

* Remove the `file_exists()` method from the Buildozer class.
* Change all the references to use the buildops function.
   * Note for consistency with the other buildop functions, buildops.file_exists() takes a single parameter rather than `*args` and doesn't join the path together. One client call needed to be changed to accommodate that.
   * Note that in several places, the code checks for the existence of *directories* with os.path.exists(). I did **not** change these over because:
     * Historically, the name has been **file**_exists().
     * With the join statement removed, this function doesn't add anything to calling `os.path.exists()` or `pathlib.Path.exists()`, so enforcing it on the code seemed counter-productive. I went with for consistency with existing code.
 I can easily be convinced to change this.
 
* Update mocks