### PR TITLE
Move checkbin and download to use buildops.

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -306,11 +306,10 @@ class TargetAndroid(Target):
         else:
             path.append(os.environ['PATH'])
         self.buildozer.environ['PATH'] = ':'.join(path)
-        checkbin = self.buildozer.checkbin
-        checkbin('Git (git)', 'git')
-        checkbin('Cython (cython)', 'cython')
-        checkbin('Java compiler (javac)', self.javac_cmd)
-        checkbin('Java keytool (keytool)', self.keytool_cmd)
+        buildops.checkbin('Git (git)', 'git')
+        buildops.checkbin('Cython (cython)', 'cython')
+        buildops.checkbin('Java compiler (javac)', self.javac_cmd)
+        buildops.checkbin('Java keytool (keytool)', self.keytool_cmd)
 
     def _p4a_have_aab_support(self):
         returncode = self._p4a(["aab", "-h"], break_on_error=False)[2]
@@ -354,9 +353,10 @@ class TargetAndroid(Target):
         self.logger.info('Android ANT is missing, downloading')
         archive = 'apache-ant-{0}-bin.tar.gz'.format(APACHE_ANT_VERSION)
         url = 'https://archive.apache.org/dist/ant/binaries/'
-        self.buildozer.download(url,
-                                archive,
-                                cwd=ant_dir)
+        buildops.download(
+            url,
+            archive,
+            cwd=ant_dir)
         self.buildozer.file_extract(archive,
                                     cwd=ant_dir)
         self.logger.info('Apache ANT installation done.')
@@ -382,9 +382,10 @@ class TargetAndroid(Target):
             os.makedirs(sdk_dir)
 
         url = 'https://dl.google.com/android/repository/'
-        self.buildozer.download(url,
-                                archive,
-                                cwd=sdk_dir)
+        buildops.download(
+            url,
+            archive,
+            cwd=sdk_dir)
 
         self.logger.info('Unpacking Android SDK')
         self.buildozer.file_extract(archive,
@@ -444,7 +445,7 @@ class TargetAndroid(Target):
         else:
             url = 'https://dl.google.com/android/ndk/'
 
-        self.buildozer.download(url,
+        buildops.download(url,
                                 archive,
                                 cwd=self.buildozer.global_platform_dir)
 
@@ -598,7 +599,7 @@ class TargetAndroid(Target):
                                                   'build-tools')
         aidl_cmd = join(self.android_sdk_dir, 'build-tools',
                         str(v_build_tools), 'aidl')
-        self.buildozer.checkbin('Aidl', aidl_cmd)
+        buildops.checkbin('Aidl', aidl_cmd)
         _, _, returncode = self.buildozer.cmd(aidl_cmd,
                                               break_on_error=False,
                                               show_output=False)

--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -75,17 +75,16 @@ class TargetIos(Target):
     def check_requirements(self):
         if sys.platform != "darwin":
             raise NotImplementedError("Only macOS is supported for iOS target")
-        checkbin = self.buildozer.checkbin
         cmd = self.buildozer.cmd
 
-        checkbin('Xcode xcodebuild', 'xcodebuild')
-        checkbin('Xcode xcode-select', 'xcode-select')
-        checkbin('Git git', 'git')
-        checkbin('Cython cython', 'cython')
-        checkbin('pkg-config', 'pkg-config')
-        checkbin('autoconf', 'autoconf')
-        checkbin('automake', 'automake')
-        checkbin('libtool', 'libtool')
+        buildops.checkbin('Xcode xcodebuild', 'xcodebuild')
+        buildops.checkbin('Xcode xcode-select', 'xcode-select')
+        buildops.checkbin('Git git', 'git')
+        buildops.checkbin('Cython cython', 'cython')
+        buildops.checkbin('pkg-config', 'pkg-config')
+        buildops.checkbin('autoconf', 'autoconf')
+        buildops.checkbin('automake', 'automake')
+        buildops.checkbin('libtool', 'libtool')
 
         self.logger.debug('Check availability of a iPhone SDK')
         sdk = cmd('xcodebuild -showsdks | fgrep "iphoneos" |'

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -47,8 +47,7 @@ class TargetOSX(Target):
                 self.logger.info('Downloading kivy...')
                 try:
                     buildops.download(
-                        f'https://kivy.org/downloads/'
-                        f'{current_kivy_vers}/Kivy.dmg',
+                        f'https://kivy.org/downloads/{current_kivy_vers}/Kivy.dmg',
                         'Kivy.dmg',
                         cwd=cwd
                     )

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -8,7 +8,7 @@ if sys.platform != 'darwin':
 
 from os.path import exists, join, abspath, dirname
 from subprocess import check_call, check_output
-import urllib
+import urllib.error
 
 import buildozer.buildops as buildops
 from buildozer.target import Target
@@ -52,7 +52,7 @@ class TargetOSX(Target):
                         'Kivy.dmg',
                         cwd=cwd
                     )
-                except urllib.Error:
+                except urllib.error.URLError:
                     self.logger.error(
                         "Unable to download the Kivy App. "
                         "Check osx.kivy_version in your buildozer.spec, and "

--- a/tests/targets/test_android.py
+++ b/tests/targets/test_android.py
@@ -10,7 +10,7 @@ from buildozer.targets.android import TargetAndroid
 from tests.targets.utils import (
     init_buildozer,
     patch_buildozer,
-    patch_buildozer_checkbin,
+    patch_buildops_checkbin,
     patch_buildozer_cmd,
     patch_buildops_file_exists,
 )
@@ -20,8 +20,8 @@ def patch_buildozer_cmd_expect():
     return patch_buildozer("cmd_expect")
 
 
-def patch_buildozer_download():
-    return patch_buildozer("download")
+def patch_buildops_download():
+    return mock.patch("buildozer.buildops.download")
 
 
 def patch_buildozer_file_extract():
@@ -155,7 +155,7 @@ class TestTargetAndroid:
         assert not hasattr(target_android, "adb_args")
         assert not hasattr(target_android, "javac_cmd")
         assert "PATH" not in buildozer.environ
-        with patch_buildozer_checkbin() as m_checkbin:
+        with patch_buildops_checkbin() as m_checkbin:
             target_android.check_requirements()
         assert m_checkbin.call_args_list == [
             mock.call("Git (git)", "git"),
@@ -182,7 +182,7 @@ class TestTargetAndroid:
     def test_install_android_sdk(self, platform):
         """Basic tests for the _install_android_sdk() method."""
         target_android = init_target(self.temp_dir)
-        with patch_buildops_file_exists() as m_file_exists, patch_buildozer_download() as m_download:
+        with patch_buildops_file_exists() as m_file_exists, patch_buildops_download() as m_download:
             m_file_exists.return_value = True
             sdk_dir = target_android._install_android_sdk()
         assert m_file_exists.call_args_list == [
@@ -191,7 +191,7 @@ class TestTargetAndroid:
         assert m_download.call_args_list == []
         assert sdk_dir.endswith(".buildozer/android/platform/android-sdk")
         with patch_buildops_file_exists() as m_file_exists, \
-                patch_buildozer_download() as m_download, \
+                patch_buildops_download() as m_download, \
                 patch_buildozer_file_extract() as m_file_extract, \
                 patch_platform(platform):
             m_file_exists.return_value = False

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -9,7 +9,7 @@ from buildozer.exceptions import BuildozerCommandException
 from buildozer.targets.ios import TargetIos
 from tests.targets.utils import (
     init_buildozer,
-    patch_buildozer_checkbin,
+    patch_buildops_checkbin,
     patch_buildozer_cmd,
     patch_buildops_file_exists,
     patch_logger_error,
@@ -56,7 +56,7 @@ class TestTargetIos:
         buildozer = target.buildozer
         assert not hasattr(target, "javac_cmd")
         assert "PATH" not in buildozer.environ
-        with patch_buildozer_checkbin() as m_checkbin:
+        with patch_buildops_checkbin() as m_checkbin:
             target.check_requirements()
         assert m_checkbin.call_args_list == [
             mock.call("Xcode xcodebuild", "xcodebuild"),

--- a/tests/targets/utils.py
+++ b/tests/targets/utils.py
@@ -14,8 +14,8 @@ def patch_buildozer_cmd():
     return patch_buildozer("cmd")
 
 
-def patch_buildozer_checkbin():
-    return patch_buildozer("checkbin")
+def patch_buildops_checkbin():
+    return mock.patch("buildozer.buildops.checkbin")
 
 
 def patch_buildops_file_exists():

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -125,7 +125,7 @@ class TestBuildozer(unittest.TestCase):
         target = TargetAndroid(buildozer=buildozer)
 
         # Mock first run
-        with mock.patch('buildozer.Buildozer.download') as download, \
+        with mock.patch('buildozer.buildops.download') as download, \
                 mock.patch('buildozer.Buildozer.file_extract') as m_file_extract, \
                 mock.patch('os.makedirs'):
             ant_path = target._install_apache_ant()


### PR DESCRIPTION
This is part of a larger refactoring to simplify the Buildozer class.

* Remove checkbin() and download() methods (plus some definitions only used by download().
* Migrates all references to use the Buildops equivalents.
* Migrate shelling out to "curl"  to use download instead.

Note: The Buildops versions have completely different implementations to the original Buildozer ones, but the semantics are the same. New versions are more platform-independent, expected to be faster and don't use deprecated  library calls.

[Note to reviewers: This should be a straightforward one, but heads up that I am expecting the *next* PR to be a doozy.