### PR TITLE
Fix a typo introduced during PR #1669

### DIFF
--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -311,7 +311,7 @@ class TargetIos(Target):
             cwd=build_dir)
 
         self.logger.info('Moving IPA to bin...')
-        buildops.file_rename(ipa_tmp, ipa)
+        buildops.rename(ipa_tmp, ipa)
 
         self.logger.info('iOS packaging done!')
         self.logger.info('IPA {0} available in the bin directory'.format(


### PR DESCRIPTION
CC: @Julian-O 

We both did not see that the method name was wrong, since we likely were too much focused on `self.buildozer` --> `buildops`.

This only means that we need to improve our tests.