### PR TITLE
Migrate to use cmd, cmd_expect and file_extract from Buildops.

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -249,7 +249,6 @@ class Target:
         :Returns:
             fully qualified path to updated git repo
         """
-        cmd = self.buildozer.cmd
         install_dir = join(self.buildozer.platform_dir, repo)
         custom_dir, clone_url, clone_branch = self.path_or_git_url(repo, **kwargs)
         if not buildops.file_exists(install_dir):
@@ -257,11 +256,20 @@ class Target:
                 buildops.mkdir(install_dir)
                 buildops.file_copytree(custom_dir, install_dir)
             else:
-                cmd(["git", "clone", "--branch", clone_branch, clone_url], cwd=self.buildozer.platform_dir)
+                buildops.cmd(
+                    ["git", "clone", "--branch", clone_branch, clone_url],
+                    cwd=self.buildozer.platform_dir,
+                    env=self.buildozer.environ)
         elif self.platform_update:
             if custom_dir:
                 buildops.file_copytree(custom_dir, install_dir)
             else:
-                cmd(["git", "clean", "-dxf"], cwd=install_dir)
-                cmd(["git", "pull", "origin", clone_branch], cwd=install_dir)
+                buildops.cmd(
+                    ["git", "clean", "-dxf"],
+                    cwd=install_dir,
+                    env=self.buildozer.environ)
+                buildops.cmd(
+                    ["git", "pull", "origin", clone_branch],
+                    cwd=install_dir,
+                    env=self.buildozer.environ)
         return install_dir

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -132,9 +132,12 @@ class TargetAndroid(Target):
                          'but you set value {}').format(section, token, value)
                 self.logger.error(error)
 
-    def _p4a(self, cmd, **kwargs):
+    def _p4a(self, cmd, env, **kwargs):
         kwargs.setdefault('cwd', self.p4a_dir)
-        return self.buildozer.cmd([*self._p4a_cmd, *cmd, *self.extra_p4a_args], **kwargs)
+        return buildops.cmd(
+            [*self._p4a_cmd, *cmd, *self.extra_p4a_args],
+            env=env,
+            **kwargs)
 
     @property
     def p4a_dir(self):
@@ -194,10 +197,11 @@ class TargetAndroid(Target):
         command = [self.sdkmanager_path, f"--sdk_root={android_sdk_dir}", *args]
 
         if kwargs.pop('return_child', False):
-            return self.buildozer.cmd_expect(command, **kwargs)
+            return buildops.cmd_expect(
+                command, env=self.buildozer.environ, **kwargs)
         else:
             kwargs['get_stdout'] = kwargs.get('get_stdout', True)
-            return self.buildozer.cmd(command, **kwargs)
+            return buildops.cmd(command, env=self.buildozer.environ, **kwargs)
 
     @property
     def android_ndk_version(self):
@@ -312,7 +316,10 @@ class TargetAndroid(Target):
         buildops.checkbin('Java keytool (keytool)', self.keytool_cmd)
 
     def _p4a_have_aab_support(self):
-        returncode = self._p4a(["aab", "-h"], break_on_error=False)[2]
+        returncode = self._p4a(
+            ["aab", "-h"],
+            break_on_error=False,
+            env=self.buildozer.environ).return_code
         if returncode == 0:
             return True
         else:
@@ -357,8 +364,10 @@ class TargetAndroid(Target):
             url,
             archive,
             cwd=ant_dir)
-        self.buildozer.file_extract(archive,
-                                    cwd=ant_dir)
+        buildops.file_extract(
+            archive,
+            cwd=ant_dir,
+            env=self.buildozer.environ)
         self.logger.info('Apache ANT installation done.')
         return ant_dir
 
@@ -388,8 +397,10 @@ class TargetAndroid(Target):
             cwd=sdk_dir)
 
         self.logger.info('Unpacking Android SDK')
-        self.buildozer.file_extract(archive,
-                                    cwd=sdk_dir)
+        buildops.file_extract(
+            archive,
+            cwd=sdk_dir,
+            env=self.buildozer.environ)
 
         self.logger.info('Android SDK tools base installation done.')
 
@@ -450,8 +461,10 @@ class TargetAndroid(Target):
                                 cwd=self.buildozer.global_platform_dir)
 
         self.logger.info('Unpacking Android NDK')
-        self.buildozer.file_extract(archive,
-                                    cwd=self.buildozer.global_platform_dir)
+        buildops.file_extract(
+            archive,
+            cwd=self.buildozer.global_platform_dir,
+            env=self.buildozer.environ)
         buildops.rename(
             unpacked,
             ndk_dir,
@@ -530,7 +543,7 @@ class TargetAndroid(Target):
 
     def _install_android_packages(self):
 
-        # if any of theses value change into the buildozer.spec, retry the
+        # if any of these values change into the buildozer.spec, retry the
         # update
         cache_key = 'android:sdk_installation'
         cache_value = [
@@ -600,9 +613,11 @@ class TargetAndroid(Target):
         aidl_cmd = join(self.android_sdk_dir, 'build-tools',
                         str(v_build_tools), 'aidl')
         buildops.checkbin('Aidl', aidl_cmd)
-        _, _, returncode = self.buildozer.cmd(aidl_cmd,
-                                              break_on_error=False,
-                                              show_output=False)
+        returncode = buildops.cmd(
+            [aidl_cmd],
+            break_on_error=False,
+            show_output=False,
+            env=self.buildozer.environ).return_code
         if returncode != 1:
             self.logger.error('Aidl cannot be executed')
             if architecture()[0] == '64bit':
@@ -627,7 +642,7 @@ class TargetAndroid(Target):
         self._install_android_packages()
 
         # ultimate configuration check.
-        # some of our configuration cannot be check without platform.
+        # some of our configuration cannot be checked without platform.
         self.check_configuration_tokens()
         if not self._p4a_have_aab_support():
             self.logger.error(
@@ -645,7 +660,6 @@ class TargetAndroid(Target):
         })
 
     def _install_p4a(self):
-        cmd = self.buildozer.cmd
         p4a_fork = self.buildozer.config.getdefault(
             'app', 'p4a.fork', self.p4a_fork
         )
@@ -672,14 +686,18 @@ class TargetAndroid(Target):
         else:
             # check that url/branch has not been changed
             if buildops.file_exists(p4a_dir):
-                cur_url = cmd(
+                cur_url = buildops.cmd(
                     ["git", "config", "--get", "remote.origin.url"],
                     get_stdout=True,
                     cwd=p4a_dir,
-                )[0].strip()
-                cur_branch = cmd(
-                    ["git", "branch", "-vv"], get_stdout=True, cwd=p4a_dir
-                )[0].split()[1]
+                    env=self.buildozer.environ
+                ).stdout.strip()
+                cur_branch = buildops.cmd(
+                    ["git", "branch", "-vv"],
+                    get_stdout=True,
+                    cwd=p4a_dir,
+                    env=self.buildozer.environ
+                ).stdout.split()[1]
                 if any([cur_url != p4a_url, cur_branch != p4a_branch]):
                     self.logger.info(
                         f"Detected old url/branch ({cur_url}/{cur_branch}), deleting..."
@@ -687,7 +705,7 @@ class TargetAndroid(Target):
                     buildops.rmdir(p4a_dir)
 
             if not buildops.file_exists(p4a_dir):
-                cmd(
+                buildops.cmd(
                     [
                         "git",
                         "clone",
@@ -698,19 +716,37 @@ class TargetAndroid(Target):
                         self.p4a_directory_name,
                     ],
                     cwd=self.buildozer.platform_dir,
+                    env=self.buildozer.environ
                 )
             elif self.platform_update:
-                cmd(["git", "clean", "-dxf"], cwd=p4a_dir)
-                current_branch = cmd(["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                                     get_stdout=True, cwd=p4a_dir)[0].strip()
+                buildops.cmd(
+                    ["git", "clean", "-dxf"],
+                    cwd=p4a_dir,
+                    env=self.buildozer.environ)
+                current_branch = buildops.cmd(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                    get_stdout=True,
+                    cwd=p4a_dir,
+                    env=self.buildozer.environ).stdout.strip()
                 if current_branch == p4a_branch:
-                    cmd(["git", "pull"], cwd=p4a_dir)
+                    buildops.cmd(
+                        ["git", "pull"],
+                        cwd=p4a_dir,
+                        env=self.buildozer.environ)
                 else:
-                    cmd(["git", "fetch", "--tags", "origin", "{0}:{0}".format(p4a_branch)],
-                        cwd=p4a_dir)
-                    cmd(["git", "checkout", p4a_branch], cwd=p4a_dir)
+                    buildops.cmd(
+                        ["git", "fetch", "--tags", "origin", "{0}:{0}".format(p4a_branch)],
+                        cwd=p4a_dir,
+                        env=self.buildozer.environ)
+                    buildops.cmd(
+                        ["git", "checkout", p4a_branch],
+                        cwd=p4a_dir,
+                        env=self.buildozer.environ)
             if p4a_commit != 'HEAD':
-                cmd(["git", "reset", "--hard", p4a_commit], cwd=p4a_dir)
+                buildops.cmd(
+                    ["git", "reset", "--hard", p4a_commit],
+                    cwd=p4a_dir,
+                    env=self.buildozer.environ)
 
         # also install dependencies (currently, only setup.py knows about it)
         # let's extract them.
@@ -728,7 +764,9 @@ class TargetAndroid(Target):
         options = ["--user"]
         if "VIRTUAL_ENV" in os.environ or "CONDA_PREFIX" in os.environ:
             options = []
-        cmd([executable, "-m", "pip", "install", "-q", *options, *deps])
+        buildops.cmd(
+            [executable, "-m", "pip", "install", "-q", *options, *deps],
+            env=self.buildozer.environ)
 
     def compile_platform(self):
         app_requirements = self.buildozer.config.getlist(
@@ -763,7 +801,7 @@ class TargetAndroid(Target):
 
         p4a_create.extend(options)
 
-        self._p4a(p4a_create, get_stdout=True)[0]
+        self._p4a(p4a_create, get_stdout=True, env=self.buildozer.environ)
 
     def get_available_packages(self):
         return True
@@ -930,7 +968,7 @@ class TargetAndroid(Target):
             cmd.append('--arch')
             cmd.append(arch)
 
-        self._p4a(cmd)
+        self._p4a(cmd, env=self.buildozer.environ)
 
     def get_release_mode(self):
         # aab, also if unsigned is named as *-release
@@ -968,7 +1006,7 @@ class TargetAndroid(Target):
         for serial in self.serials:
             self.buildozer.environ['ANDROID_SERIAL'] = serial
             self.logger.info('Run on {}'.format(serial))
-            self.buildozer.cmd(
+            buildops.cmd(
                 [
                     self.adb_executable,
                     *self.adb_args,
@@ -981,6 +1019,7 @@ class TargetAndroid(Target):
                     entrypoint,
                 ],
                 cwd=self.buildozer.global_platform_dir,
+                env=self.buildozer.environ
             )
         self.buildozer.environ.pop('ANDROID_SERIAL', None)
 
@@ -1006,14 +1045,14 @@ class TargetAndroid(Target):
                   .format(self.targetname))
             sys.stderr.write('PYTHONPATH={} {}\n'.format(self.p4a_dir, self._p4a_cmd))
         else:
-            self._p4a(args)
+            self._p4a(args, env=self.buildozer.environ)
 
     def cmd_clean(self, *args):
         '''
         Clean the build and distribution
         '''
-        self._p4a(["clean_builds"])
-        self._p4a(["clean_dists"])
+        self._p4a(["clean_builds"], env=self.buildozer.environ)
+        self._p4a(["clean_dists"], env=self.buildozer.environ)
 
     def _get_package(self):
         config = self.buildozer.config
@@ -1360,9 +1399,11 @@ class TargetAndroid(Target):
         serial = environ.get('ANDROID_SERIAL')
         if serial:
             return serial.split(',')
-        lines = self.buildozer.cmd(
-            [self.adb_executable, *self.adb_args, "devices"], get_stdout=True
-        )[0].splitlines()
+        lines = buildops.cmd(
+            [self.adb_executable, *self.adb_args, "devices"],
+            get_stdout=True,
+            env=self.buildozer.environ
+        ).stdout.splitlines()
         serials = []
         for serial in lines:
             if not serial:
@@ -1388,7 +1429,9 @@ class TargetAndroid(Target):
                   .format(self.targetname))
             sys.stderr.write(self.adb_executable + '\n')
         else:
-            self.buildozer.cmd([self.adb_executable, *self.adb_args, *args])
+            buildops.cmd(
+                [self.adb_executable, *self.adb_args, *args],
+                env=self.buildozer.environ)
 
     def cmd_deploy(self, *args):
         super().cmd_deploy(*args)
@@ -1411,16 +1454,17 @@ class TargetAndroid(Target):
         for serial in self.serials:
             self.buildozer.environ['ANDROID_SERIAL'] = serial
             self.logger.info('Deploy on {}'.format(serial))
-            self.buildozer.cmd(
+            buildops.cmd(
                 [self.adb_executable, *self.adb_args, "install", "-r", full_apk],
                 cwd=self.buildozer.global_platform_dir,
+                env=self.buildozer.environ
             )
         self.buildozer.environ.pop('ANDROID_SERIAL', None)
 
         self.logger.info('Application pushed.')
 
     def _get_pid(self):
-        pid, *_ = self.buildozer.cmd(
+        pid = buildops.cmd(
             [
                 self.adb_executable,
                 *self.adb_args,
@@ -1432,7 +1476,8 @@ class TargetAndroid(Target):
             show_output=False,
             break_on_error=False,
             quiet=True,
-        )
+            env=self.buildozer.environ
+        ).stdout
         if pid:
             return pid.strip()
         return False
@@ -1459,12 +1504,13 @@ class TargetAndroid(Target):
             if pid:
                 extra_args.extend(('--pid', pid))
 
-        self.buildozer.cmd(
+        buildops.cmd(
             [self.adb_executable, *self.adb_args, "logcat", filters, *extra_args],
             cwd=self.buildozer.global_platform_dir,
             show_output=True,
             run_condition=self._get_pid if pid else None,
             break_on_error=False,
+            env=self.buildozer.environ
         )
 
         self.logger.info(f"{self._get_package()} terminated")

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -33,7 +33,8 @@ class TargetOSX(Target):
             'https://github.com/kivy/kivy-sdk-packager/archive/master.zip',
             'master.zip',
             cwd=platdir)
-        check_call(('unzip', 'master.zip'), cwd=platdir)
+        buildops.file_extract(
+            'master.zip', cwd=platdir, env=self.buildozer.environ)
         buildops.file_remove(join(platdir, 'master.zip'))
 
     def download_kivy(self, cwd):


### PR DESCRIPTION

This is part of a bigger refactor to reduce the size and complexity of the Buildozer class (and bring it closer to cross-platform).

* Remove buildozer's cmd, cmd_expect and file_extract functions, and tests.

* Migrate clients to use buildops.cmd()
  * Note that the implementation is completely different.
    * Particularly, it doesn't depend on fcntl, so it runs cross-platform.
	* It is much more explicit about the parameters it accepts.
	* It no longer accepts `sensible` param; `quiet` has the same effect.
	* It returns a named tuple, rather than a tuple; took advantage of replacing "magic number" indices with meaningful names.
    * The treatment of environment variables has changed.
      * Old system:
        * buildozer.environ contained a list of deltas - overrides to the os.environ variables.
        * buildozer.cmd()'s env parameter was bigger override.
        * buildozer.cmd() would use the env parameter (and only the env parameter), unless it were None, in which case it would grab os.environ and apply buildozer.environ on top.
      * New system:
        * buildozer.environ isn't available to the library function buildops.cmd().
        * So, now the environment must be passed. It becomes the client's task to pass it.
        * Rather than having every client have to merge the os.environ and buildozer.environ together, the definition of buildozer.environ has been changed. It now is not the delta, but the complete set of env vars. (It now defaults to os.environ, rather than [].)
        * It may be the case that many commands do not care about env vars, and the clients would rather omit the parameter. `buildops.cmd()` could be made to default to os.environ. I did not do this, because I can't tell which need special env vars. I wanted to ensure that every call was updated to include the env. Once that migration is done, it *could* be modified to accept a default. Leaving that for future refactors.
	* Most commands being run, at first inspection at least, look like they should work on darwin, linux and win32. Added assert statements where the command is clearly not going to run cross-platform.
	* ios.py contained a complicated pipe command that required a shell. Rather than supporting shells in `cmd`, I ported the client code to Python - which is a better solution for maintenance.

* Migrate clients to use buildops.cmd_expect()
   * This remains platform-dependent, but is only used to automate accepting Android SDK licenses.
   * Making this platform-independent is left for future refactors.
   * Also now requires env param.
   
* Migrate clients to use buildops.file_extract()
   * The implementation has been substantially rewritten (platform-independent and should be faster because it doesn't normally spawn shells.)
   * It still, rather unexpectedly, will *run* a .bin file if passed. I do not know if that feature is ever used.
      * Running a .bin depends on `cmd()` and also now needs an environ parameter. [This is the reason I had to bundle it with this larger PR.]
      * Running a .bin is not platform independent, but this is likely to never come up in practice - Windows versions of SDKs/NDKs etc don't require .bin files to be executed.
   * Fixed one call from `osx.py` to use extract_file instead of cmd('unzip')
	  
* Last minute: Rolled back changes to extracting zipfiles. 
   * Buildops.extract_file now uses the `unzip` shell command (which is not platform dependent).
   * Python's zipfile doesn't support extracting file permissions. I modified extract_file to chmod as appropriate.
   * That wasn't enough. `pythonforandroid.toolchain create` was failing with the config script complaining about an error in `/home/runner/work/buildozer/buildozer/.buildozer/android/platform/build-arm64-v8a_armeabi-v7a/build/other_builds/libffi/armeabi-v7a__ndk_target_21/libffi` and hence `C compiler cannot create executables`, but only on the CI machine; it works fine on my VirtualBox test machine. Still figuring out what might be different. Hints welcome!
   * Changed tests to match. (Needed more from the logger mock, and behaviour when the file is missing is less specific. In practice, this doesn't occur.)
	  
* Trivial changes	  
	* Corrected the grammar of a few comments.
	* Improved the indenting of some of Buildops code.