### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup environment
       run: |
         pip install -e .

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - uses: actions/checkout@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup python
       # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
       if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - uses: actions/checkout@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Setup python
       # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
       if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup environment
       run: |
         source .ci/osx_ci.sh

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,9 +5,9 @@ jobs:
   pypi_release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.x
     - name: Install dependencies

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.x
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Install dependencies

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -11,7 +11,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/support-requests@v2
+      - uses: dessant/support-requests@v3
         with:
           github-token: ${{ github.token }}
           support-label: 'support'

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -18,10 +18,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python }}
 
@@ -39,7 +39,7 @@ jobs:
   Docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Docker build
       run: docker build --tag=kivy/buildozer .
     - name: Docker run


### PR DESCRIPTION
In the various YAML files, the Github actions are locked to particular versions.

Some actions are out of date and are causing deprecation annotations. e.g.:

> **pypi_release**
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

This PR updates all of the actions to the latest.

I briefly looked for any changes that affected this CI, but I didn't find any, which was as expected.