### PR TITLE
Add tests of the documentation.

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -44,3 +44,15 @@ jobs:
       run: docker build --tag=kivy/buildozer .
     - name: Docker run
       run: docker run kivy/buildozer --version
+
+  Documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Requirements
+      run: pip install -U sphinx
+    - name: Check links
+      run: sphinx-build -b linkcheck docs/source docs/build
+    - name: Generate documentation
+      run: sphinx-build docs/source docs/build
+


### PR DESCRIPTION
The RST files in a pull request might be malformed. URLs might be broken. These should be included in the unit-tests so they are immediately noticed.

This runs a Sphinx build on the documentation (and throws away the result). It also runs a URL check.

Note: The existing documents have some warnings - look for a separate PR to address those.

I did experiment, and confirm that an error like a bad URL causes this test to fail.