### PR TITLE
Use suggested (latest) Python3 version to perform Android builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.x'
     - uses: actions/checkout@v4
     - name: Setup environment
       run: |


### PR DESCRIPTION
`buildozer` is already tested against all the supported Python versions.

During Android builds there's no need to stick on a specific Python version.