### PR TITLE
Improve Buildozer's venv handling.

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -235,6 +235,7 @@ class Buildozer:
                         target_available_packages]
 
         # Technique defined in venv library documentation.
+        # See: https://docs.python.org/3/library/venv.html#how-venvs-work
         currently_in_venv = sys.prefix != sys.base_prefix
 
         if requirements and currently_in_venv:


### PR DESCRIPTION
* The mechanism used to determine if it was currently running in a venv was non-standard. Used technique recommended by [venv documentation](https://docs.python.org/3/library/venv.html#how-venvs-work).
* Rather than call a subprocess to run venv, use the built-in venv library.
* Rather than check if an attribute exists, define it in `__init__()` and see if it has changed.
* `self.venv` contained a directory path, but the folder name didn't need to be stored after the method returned. A Boolean was all that was required.

Also, some trivial clean ups thrown in:
* Comment improvements.
* Copy command didn't need to be logged; buildops will do that.
* Directory's existence doesn't need to be checked; buildops will do that.