### PR TITLE
Clean up inheritance of targets

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -15,7 +15,6 @@ class Target:
     def __init__(self, buildozer):
         self.buildozer = buildozer
         self.build_mode = 'debug'
-        self.artifact_format = 'apk'
         self.platform_update = False
         self.logger = Logger()
 
@@ -106,7 +105,6 @@ class Target:
     def cmd_debug(self, *args):
         self.buildozer.prepare_for_build()
         self.build_mode = 'debug'
-        self.artifact_format = self.buildozer.config.getdefault('app', 'android.debug_artifact', 'apk')
         self.buildozer.build()
 
     def cmd_release(self, *args):
@@ -143,7 +141,6 @@ class Target:
                 exit(1)
 
         self.build_mode = 'release'
-        self.artifact_format = self.buildozer.config.getdefault('app', 'android.release_artifact', 'aab')
         self.buildozer.build()
 
     def cmd_deploy(self, *args):

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -72,6 +72,9 @@ class TargetAndroid(Target):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.artifact_format = 'apk'
+
         if self.buildozer.config.has_option(
             "app", "android.arch"
         ) and not self.buildozer.config.has_option("app", "android.archs"):
@@ -988,6 +991,14 @@ class TargetAndroid(Target):
                          "--sign will not be passed").format(key))
                 check = False
         return check
+
+    def cmd_debug(self, *args):
+        self.artifact_format = self.buildozer.config.getdefault('app', 'android.debug_artifact', 'apk')
+        super().cmd_debug(*args)
+
+    def cmd_release(self, *args):
+        self.artifact_format = self.buildozer.config.getdefault('app', 'android.release_artifact', 'aab')
+        super().cmd_release(*args)
 
     def cmd_run(self, *args):
         entrypoint = self.buildozer.config.getdefault(

--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -79,17 +79,6 @@ class TargetOSX(Target):
         self.ensure_sdk()
         self.ensure_kivyapp()
 
-    def check_configuration_tokens(self, errors=None):
-        if errors:
-            self.logger.info('Check target configuration tokens')
-            self.logger.error(
-                '{0} error(s) found in the buildozer.spec'.format(
-                    len(errors)))
-            for error in errors:
-                print(error)
-            sys.exit(1)
-        # check
-
     def build_package(self):
         self.logger.info('Building package')
 
@@ -147,9 +136,6 @@ class TargetOSX(Target):
             binpath)
         self.logger.info('All Done!')
 
-    def compile_platform(self):
-        pass
-
     def install_platform(self):
         # ultimate configuration check.
         # some of our configuration cannot be checked without platform.
@@ -158,16 +144,6 @@ class TargetOSX(Target):
         self.buildozer.environ.update({
             'PACKAGES_PATH': self.buildozer.global_packages_dir,
         })
-
-    def get_custom_commands(self):
-        result = []
-        for x in dir(self):
-            if not x.startswith('cmd_'):
-                continue
-            if x[4:] in self.buildozer.standard_cmds:
-                continue
-            result.append((x[4:], getattr(self, x).__doc__))
-        return result
 
     def get_available_packages(self):
         return ['kivy', 'python3']
@@ -211,36 +187,6 @@ class TargetOSX(Target):
                 self.check_configuration_tokens()
 
             func(args)
-
-    def check_build_prepared(self):
-        self._build_prepared = False
-
-    def cmd_clean(self, *args):
-        self.buildozer.clean_platform()
-
-    def cmd_update(self, *args):
-        self.platform_update = True
-        self.buildozer.prepare_for_build()
-
-    def cmd_debug(self, *args):
-        self.buildozer.prepare_for_build()
-        self.build_mode = 'debug'
-        self.check_build_prepared()
-        self.buildozer.build()
-
-    def cmd_release(self, *args):
-        self.buildozer.prepare_for_build()
-        self.build_mode = 'release'
-        self.buildozer.build()
-
-    def cmd_deploy(self, *args):
-        self.buildozer.prepare_for_build()
-
-    def cmd_run(self, *args):
-        self.buildozer.prepare_for_build()
-
-    def cmd_serve(self, *args):
-        self.buildozer.cmd_serve()
 
 
 def get_target(buildozer):


### PR DESCRIPTION
1) Target class contained Android-only attribute "artifact_format". Moved that code into TargetAndroid class.

2) TargetIos had a `check_build_prepared()` method that was ineffective.

`prepare_for_build()` sets `target._build_prepared` to True. Then `check_build_prepared()` inexplicably set it to False. Then `build()` checks for its existence, rather than its value [this is code smell that is on my list for later], so the fact that it had been changed made no difference.

So, I removed the method, and the call to it.

2) TargetOSX had lots of methods that were identical to its base class implementations (three more, once the above steps were done). They don't need to be specified; they are inherited. I removed them. `osx.py` is now 20% smaller.