### PR TITLE
Add alternate unzip implementation

### DIFF
--- a/tests/test_buildops.py
+++ b/tests/test_buildops.py
@@ -241,10 +241,14 @@ class TestBuildOps(TestCase):
             m_logger.reset_mock()
 
             nonexistent_path = Path(base_dir) / "nonexistent.zip"
-            with self.assertRaises(BuildozerCommandException):
+            try:
                 buildops.file_extract(nonexistent_path, environ)
-            m_logger.debug.assert_called()
-            m_logger.error.assert_called()
+                self.fail("No exception raised")
+            except FileNotFoundError:
+                pass  # This is raised by zipfile on Windows.
+            except BuildozerCommandException:
+                pass  # This is raised by cmd when not on Windows.
+
             m_logger.reset_mock()
 
             # Create a zip file and unzip it.


### PR DESCRIPTION
Turns out Linux and the `zipfile` package don't get along, while Windows and `unzip` don't get along.

Provide both implementations, so it always works.

[This doesn't meet my stated goal of making all Windows-specific improvements also include making the code cleaner for other developers too. Sorry.]