### PR TITLE
Remove some attributes defined outside of __init__()

### DIFF
--- a/buildozer/__init__.py
+++ b/buildozer/__init__.py
@@ -40,6 +40,8 @@ class Buildozer:
         self.build_id = None
         self.config = SpecParser()
         self._venv_created = False
+        self._build_prepared = False
+        self._build_done = False
 
         self.logger = Logger()
 
@@ -77,7 +79,7 @@ class Buildozer:
         '''Prepare the build.
         '''
         assert self.target is not None
-        if hasattr(self.target, '_build_prepared'):
+        if self._build_prepared:
             return
 
         self.logger.info('Preparing build')
@@ -97,7 +99,7 @@ class Buildozer:
         self.target.compile_platform()
 
         # flag to prevent multiple build
-        self.target._build_prepared = True
+        self._build_prepared = True
 
     def build(self):
         '''Do the build.
@@ -108,9 +110,9 @@ class Buildozer:
         (:meth:`prepare_for_build` must have been call before.)
         '''
         assert self.target is not None
-        assert hasattr(self.target, '_build_prepared')
+        assert self._build_prepared
 
-        if hasattr(self.target, '_build_done'):
+        if self._build_done:
             return
 
         # increment the build number
@@ -124,7 +126,7 @@ class Buildozer:
         self.target.build_package()
 
         # flag to prevent multiple build
-        self.target._build_done = True
+        self._build_done = True
 
     def check_configuration_tokens(self):
         '''Ensure the spec file is 'correct'.

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -74,6 +74,7 @@ class TargetAndroid(Target):
         super().__init__(*args, **kwargs)
 
         self.artifact_format = 'apk'
+        self._serials = None
 
         if self.buildozer.config.has_option(
             "app", "android.arch"
@@ -1405,7 +1406,7 @@ class TargetAndroid(Target):
 
     @property
     def serials(self):
-        if hasattr(self, '_serials'):
+        if self._serials is not None:
             return self._serials
         serial = environ.get('ANDROID_SERIAL')
         if serial:


### PR DESCRIPTION
Attributes of a class instance should, where possible, be defined in the `__init__()` method, for clarity (especially about lifetimes). Pylint has a [warning about this](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/attribute-defined-outside-init.html), but I can't see one from Flake8.

TargetAndroid has an attribute `_serials` which is defined  (*sometimes*) outside of `__init()__`, and its value is checked with `hasattr()`. Changed it to act like a normal instance attribute, defined in `__init__()`.

Buildozer() goes even further. It monkey-patches two attributes, `_build_prepared` and `_build_done` onto its associated target. These attributes have the same lifetime as the Buildozer instance. I removed the monkey-patching, and made them normal instance attributes of Buildozer, defined in `__init__()`.