### PR TITLE
Remove empty except clauses

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -31,7 +31,6 @@ import shlex
 from shutil import which
 from sys import platform, executable
 from time import sleep
-import traceback
 
 from distutils.version import LooseVersion
 import pexpect
@@ -273,10 +272,7 @@ class TargetAndroid(Target):
 
     def check_requirements(self):
         if platform in ('win32', 'cygwin'):
-            try:
-                self._set_win32_java_home()
-            except:
-                traceback.print_exc()
+            self._set_win32_java_home()
             self.adb_executable = join(self.android_sdk_dir, 'platform-tools',
                                 'adb.exe')
             self.javac_cmd = self._locate_java('javac.exe')
@@ -522,10 +518,7 @@ class TargetAndroid(Target):
                 *args)))
             return parse("0")
         for v in os.listdir(join(*args)):
-            try:
-                versions.append(parse(v))
-            except:
-                pass
+            versions.append(parse(v))
         if not versions:
             self.logger.error(
                 'Unable to find the latest version for {}'.format(join(*args)))
@@ -1296,14 +1289,6 @@ class TargetAndroid(Target):
 
         self.execute_build_package(build_cmd)
 
-        try:
-            self.buildozer.hook("android_pre_build_apk")
-            self.execute_build_package(build_cmd)
-            self.buildozer.hook("android_post_build_apk")
-        except:
-            # maybe the hook fail because the apk is not
-            pass
-
         build_tools_versions = os.listdir(join(self.android_sdk_dir, "build-tools"))
         build_tools_versions = sorted(build_tools_versions, key=LooseVersion)
         build_tools_version = build_tools_versions[-1]
@@ -1391,11 +1376,7 @@ class TargetAndroid(Target):
 
         # recreate the project.properties
         with io.open(project_fn, 'w', encoding='utf-8') as fd:
-
-            try:
-                fd.writelines((line.decode('utf-8') for line in content))
-            except:
-                fd.writelines(content)
+            fd.writelines(content)
             if content and not content[-1].endswith(u'\n'):
                 fd.write(u'\n')
             for index, ref in enumerate(references):


### PR DESCRIPTION
[Empty except clauses are code smell](https://stackoverflow.com/questions/14797375/should-i-always-specify-an-exception-type-in-except-statements/). At the very least, they can unintentionally catch KeyboardInterrupt and SystemExit exceptions. At worse, they can hide bugs.

Looking through Buildozer code, there are four empty except clauses in `android.py`.

One protects a call to set_win32_java_home() (on Windows machines), Given win32 isn't yet supported, this is moot, but there doesn't seem to be a justification for ignoring exceptions in this scenario - if setting the home fails, Buildozer should fail. Deleted try block.

One protects a parse of the app version number. The called code already catches the most obvious exception (a badly-formatted version number). There don't seem to be any other expected exceptions, so there is not reason to swallow this exception. Deleted try block.

One is harder to understand. After calling `execute_built_package()`, a try block attempts to call it **again**, surrounded by calls to run a pre-build and post-build hook on buildozer. However, the hook is never defined anywhere. This always dies with an `AttributeError` which is swallowed and ignore by the empty exception block, without the duplicate call to build. I am guessing it is a carry-over from an attempt to make Buildozer support hooks. This is an example of why not to use empty Exception blocks! Removed the try block and the protected code.

The fourth example protects an attempt to decode Unicode. `content` is read from a IO object opened in 'r' mode, so it will always be a `str` and will never have a `decode()` attribute, so this will always fail. Removed the code in the try block and just kept the except: part.