### PR TITLE
Add syntax highlighting to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Buildozer
-=========
+# Buildozer
 
 [![Tests](https://github.com/kivy/buildozer/workflows/Tests/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3ATests)
 [![Android](https://github.com/kivy/buildozer/workflows/Android/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AAndroid)
@@ -29,6 +28,7 @@ Note that this tool has nothing to do with the eponymous online build service
 ## Installing Buildozer with target Python 3 (default):
 
 - Install buildozer:
+
 ```bash
 # via pip (latest stable, recommended)
 # if you use a virtualenv, don't use the `--user` option
@@ -44,15 +44,19 @@ cd buildozer
 python setup.py build
 pip install -e .
 ```
+
 - Check buildozer is in your path
+
 ```bash
 which buildozer
 ```
+
 if there is no result, and you installed with `--user`, add this line at the end of your `~/.bashrc` (or `~/.zshrc` if you use zsh) file:
 `export PATH=~/.local/bin/:$PATH`, and then run
 `. ~/.bashrc` (or `. ~/.zshrc`)
 
 - Go into your application directory and run:
+
 ```bash
 buildozer init
 # edit the buildozer.spec, then
@@ -64,18 +68,21 @@ buildozer android debug deploy run
 A Dockerfile is available to use buildozer through a Docker environment.
 
 - Build with:
+
 ```bash
 docker build --tag=buildozer .
 ```
 
 - Run with:
+
 ```
 docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
 ```
 
-
 ### Example Build with Caching
-- Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
+
+- Build and keep downloaded SDK and NDK in `~/.buildozer` directory:
+
 ```bash
 docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
 ```
@@ -85,7 +92,6 @@ docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcw
 Use [ArtemSBulgakov/buildozer-action@v1](https://github.com/ArtemSBulgakov/buildozer-action)
 to build your packages automatically on push or pull request.
 See [full workflow example](https://github.com/ArtemSBulgakov/buildozer-action#full-workflow).
-
 
 ## Examples of Buildozer commands
 
@@ -104,56 +110,51 @@ buildozer android debug deploy
 buildozer setdefault android debug deploy run
 ```
 
-
 ## Usage
 
 ```yml
-Usage:
-    buildozer [--profile <name>] [--verbose] [target] <command>...
-    buildozer --version
+Usage: buildozer [--profile <name>] [--verbose] [target] <command>...
+  buildozer --version
 
 Available targets:
-    android        Android target, based on python-for-android project
-    ios            iOS target, based on kivy-ios project
+  android        Android target, based on python-for-android project
+  ios            iOS target, based on kivy-ios project
 
 Global commands (without target):
-    distclean          Clean the whole Buildozer environment
-    help               Show the Buildozer help
-    init               Create an initial buildozer.spec in the current directory
-    serve              Serve the bin directory via SimpleHTTPServer
-    setdefault         Set the default command to run when no arguments are given
-    version            Show the Buildozer version
+  distclean          Clean the whole Buildozer environment
+  help               Show the Buildozer help
+  init               Create an initial buildozer.spec in the current directory
+  serve              Serve the bin directory via SimpleHTTPServer
+  setdefault         Set the default command to run when no arguments are given
+  version            Show the Buildozer version
 
-Target commands:
-    clean      Clean the target environment
-    update     Update the target dependencies
-    debug      Build the application in debug mode
-    release    Build the application in release mode
-    deploy     Deploy the application on the device
-    run        Run the application on the device
-    serve      Serve the bin directory via SimpleHTTPServer
+Target commands: clean      Clean the target environment
+  update     Update the target dependencies
+  debug      Build the application in debug mode
+  release    Build the application in release mode
+  deploy     Deploy the application on the device
+  run        Run the application on the device
+  serve      Serve the bin directory via SimpleHTTPServer
 
 Target "ios" commands:
-    list_identities    List the available identities to use for signing.
-    xcode              Open the xcode project.
+  list_identities    List the available identities to use for signing.
+  xcode              Open the xcode project.
 
 Target "android" commands:
-    adb                Run adb from the Android SDK. Args must come after --, or
-                        use --alias to make an alias
-    logcat             Show the log from the device
-    p4a                Run p4a commands. Args must come after --, or use --alias
-                        to make an alias
+  adb                Run adb from the Android SDK. Args must come after --, or
+  use --alias to make an alias
+  logcat             Show the log from the device
+  p4a                Run p4a commands. Args must come after --, or use --alias
+  to make an alias
 ```
-
 
 ## `buildozer.spec`
 
 See [buildozer/default.spec](https://raw.github.com/kivy/buildozer/master/buildozer/default.spec) for an up-to-date spec file.
 
-
 ## Default config
 
-You can override the value of *any* `buildozer.spec` config token by
+You can override the value of _any_ `buildozer.spec` config token by
 setting an appropriate environment variable. These are all of the
 form `$SECTION_TOKEN`, where SECTION is the config file section and
 TOKEN is the config token to override. Dots are replaced by
@@ -170,8 +171,8 @@ config, along with the environment variables that would override them.
 
 If you need assistance, you can ask for help on our mailing list:
 
-* User Group : https://groups.google.com/group/kivy-users
-* Email      : kivy-users@googlegroups.com
+- User Group : https://groups.google.com/group/kivy-users
+- Email : kivy-users@googlegroups.com
 
 Discord channel:
 
@@ -179,7 +180,6 @@ Server : https://chat.kivy.org
 Channel : #support
 
 For [debugging on Android](https://python-for-android.readthedocs.io/en/stable/troubleshooting/?highlight=adb#debugging-on-android), don't hesitate to use ADB to get logs of your application.
-
 
 ## Contributing
 
@@ -190,26 +190,24 @@ feel free to improve buildozer.
 The following mailing list and IRC channel are used exclusively for
 discussions about developing the Kivy framework and its sister projects:
 
-* Dev Group : https://groups.google.com/group/kivy-dev
-* Email     : kivy-dev@googlegroups.com
+- Dev Group : https://groups.google.com/group/kivy-dev
+- Email : kivy-dev@googlegroups.com
 
 We also have a Discord channel:
 
-* Server     : https://chat.kivy.org
-* Channel    : #dev
+- Server : https://chat.kivy.org
+- Channel : #dev
 
 ## License
 
 Buildozer is released under the terms of the MIT License. Please refer to the
 LICENSE file.
 
-
 ## Backers
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/kivy#backer)]
 
 <a href="https://opencollective.com/kivy#backers" target="_blank"><img src="https://opencollective.com/kivy/backers.svg?width=890"></a>
-
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ pip install -e .
 ```bash
 which buildozer
 ```
-if there is no result, and you installed with `--user`, add this line at the end of your `~/.bashrc` file:
-`export PATH=~/.local/bin/:$PATH`
-# and then run
-. ~/.bashrc
+if there is no result, and you installed with `--user`, add this line at the end of your `~/.bashrc` (or `~/.zshrc` if you use zsh) file:
+`export PATH=~/.local/bin/:$PATH`, and then run
+`. ~/.bashrc` (or `. ~/.zshrc`)
 
 - Go into your application directory and run:
 ```bash
@@ -156,16 +155,16 @@ See [buildozer/default.spec](https://raw.github.com/kivy/buildozer/master/buildo
 
 You can override the value of *any* `buildozer.spec` config token by
 setting an appropriate environment variable. These are all of the
-form ``$SECTION_TOKEN``, where SECTION is the config file section and
+form `$SECTION_TOKEN`, where SECTION is the config file section and
 TOKEN is the config token to override. Dots are replaced by
 underscores.
 
-For example, here are some config tokens from the [app] section of the
+For example, here are some config tokens from the `[app]` section of the
 config, along with the environment variables that would override them.
 
-- ``title`` -> ``$APP_TITLE``
-- ``package.name`` -> ``$APP_PACKAGE_NAME``
-- ``p4a.source_dir`` -> ``$APP_P4A_SOURCE_DIR``
+- `title` -> `$APP_TITLE`
+- `package.name` -> `$APP_PACKAGE_NAME`
+- `p4a.source_dir` -> `$APP_P4A_SOURCE_DIR`
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ Note that this tool has nothing to do with the eponymous online build service
 
 - Install buildozer:
 ```bash
-      # via pip (latest stable, recommended)
-      # if you use a virtualenv, don't use the `--user` option
-      pip install --user buildozer
+# via pip (latest stable, recommended)
+# if you use a virtualenv, don't use the `--user` option
+pip install --user buildozer
 
-      # latest dev version
-      # if you use a virtualenv, don't use the `--user` option
-      pip install --user https://github.com/kivy/buildozer/archive/master.zip
+# latest dev version
+# if you use a virtualenv, don't use the `--user` option
+pip install --user https://github.com/kivy/buildozer/archive/master.zip
 
-      # git clone, for working on buildozer
-      git clone https://github.com/kivy/buildozer
-      cd buildozer
-      python setup.py build
-      pip install -e .
+# git clone, for working on buildozer
+git clone https://github.com/kivy/buildozer
+cd buildozer
+python setup.py build
+pip install -e .
 ```
 - Check buildozer is in your path
 ```bash
@@ -66,7 +66,7 @@ A Dockerfile is available to use buildozer through a Docker environment.
 
 - Build with:
 ```bash
-      docker build --tag=buildozer .
+docker build --tag=buildozer .
 ```
 
 - Run with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note that this tool has nothing to do with the eponymous online build service
 ## Installing Buildozer with target Python 3 (default):
 
 - Install buildozer:
-
+```bash
       # via pip (latest stable, recommended)
       # if you use a virtualenv, don't use the `--user` option
       pip install --user buildozer
@@ -43,40 +43,43 @@ Note that this tool has nothing to do with the eponymous online build service
       cd buildozer
       python setup.py build
       pip install -e .
-
+```
 - Check buildozer is in your path
-
-      `which buildozer`
-      # if there is no result, and you installed with --user, add this line at the end of your `~/.bashrc` file.
-      export PATH=~/.local/bin/:$PATH
-      # and then run
-      . ~/.bashrc
+```bash
+which buildozer
+```
+if there is no result, and you installed with `--user`, add this line at the end of your `~/.bashrc` file:
+`export PATH=~/.local/bin/:$PATH`
+# and then run
+. ~/.bashrc
 
 - Go into your application directory and run:
-
-      buildozer init
-      # edit the buildozer.spec, then
-      buildozer android debug deploy run
-
+```bash
+buildozer init
+# edit the buildozer.spec, then
+buildozer android debug deploy run
+```
 
 ## Buildozer Docker image
 
 A Dockerfile is available to use buildozer through a Docker environment.
 
 - Build with:
-
+```bash
       docker build --tag=buildozer .
+```
 
 - Run with:
-
-      docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+```
+docker run --volume "$(pwd)":/home/user/hostcwd buildozer --version
+```
 
 
 ### Example Build with Caching
 - Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
-
-      docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
-
+```bash
+docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
+```
 
 ## Buildozer GitHub action
 
@@ -87,7 +90,7 @@ See [full workflow example](https://github.com/ArtemSBulgakov/buildozer-action#f
 
 ## Examples of Buildozer commands
 
-```
+```bash
 # buildozer target command
 buildozer android clean
 buildozer android update
@@ -105,7 +108,7 @@ buildozer setdefault android debug deploy run
 
 ## Usage
 
-```
+```yml
 Usage:
     buildozer [--profile <name>] [--verbose] [target] <command>...
     buildozer --version

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Global commands (without target):
   setdefault         Set the default command to run when no arguments are given
   version            Show the Buildozer version
 
-Target commands: clean      Clean the target environment
+Target commands: 
+  clean      Clean the target environment
   update     Update the target dependencies
   debug      Build the application in debug mode
   release    Build the application in release mode
@@ -145,7 +146,7 @@ Target "android" commands:
   use --alias to make an alias
   logcat             Show the log from the device
   p4a                Run p4a commands. Args must come after --, or use --alias
-  to make an alias
+                     to make an alias
 ```
 
 ## `buildozer.spec`


### PR DESCRIPTION
This would add syntax highlighting to the README, and the zsh shell case in the "Check buildozer is in your path" section