### PR TITLE
Stop No Response action running when unneeded.

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,11 +6,13 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Schedule for an arbitrary time (5am) once every day
+    - cron: '* 5 * * *'
 
 jobs:
   noResponse:
+    # Don't run if in a fork
+    if: github.repository_owner == 'kivy'
     runs-on: ubuntu-latest
     steps:
       - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb


### PR DESCRIPTION
1) The No Response action is running every 5 minutes, wasting CPU. Once a day is plenty.

2) If you fork the repository in order to contribute, and you want the CI test actions to run on each commit, you can inherit the original actions from the main repo. However, that also inherits No Response action, which can't run without an issue tracker. As a result, you receive a spurious error email every time No Response runs. While it is possible to individually exclude actions with some sort of regular expression parameter in the GitHub web-site, it is neater to have the action automatically skip if it isn't in the Kivy/* domain.