### PR TITLE
Add macOS build instructions, upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 #
 # Build with:
 # docker build --tag=kivy/buildozer .
-# 
+#
+# Or for macOS using Docker Desktop:
+#
+# docker buildx build --platform=linux/amd64 -t kivy/buildozer .
+#
 # In order to give the container access to your current working directory
 # it must be mounted using the --volume option.
 # Run with (e.g. `buildozer --version`):
@@ -24,7 +28,7 @@
 # Or simply recreate the directory from the host with:
 # rm -rf ~/.buildozer && mkdir ~/.buildozer
 
-FROM ubuntu:20.04
+FROM ubuntu:latest
 
 ENV USER="user"
 ENV HOME_DIR="/home/${USER}"
@@ -55,7 +59,7 @@ RUN apt update -qq > /dev/null \
     libltdl-dev \
     libssl-dev \
     libtool \
-    openjdk-13-jdk \
+    openjdk-17-jdk \
     patch \
     pkg-config \
     python3-pip \

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ A Dockerfile is available to use buildozer through a Docker environment.
 docker build --tag=buildozer .
 ```
 
+For macOS, build with:
+
+```bash
+docker buildx build --platform=linux/amd64 -t kivy/buildozer .
+```
+
 - Run with:
 
 ```bash


### PR DESCRIPTION
Add macOS build instructions (requires different build type on Apple Silicon because it needs x86-amd64 emulation)
Upgrade Ubuntu to latest LTS
Upgrade JDK to required JDK 17, builds did not work with old JDK