### PR TITLE
Sunset `apple-silicon-m1` self-hosted runner, as now is supported by Github Hosted runners via `macos-latest` tag. Use `macos-13` for runs on Intel macs

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: [macos-latest, apple-silicon-m1]
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: [macos-latest, macos-13]
     steps:
     - name: Setup python
       uses: actions/setup-python@v4


### PR DESCRIPTION
The time has come, as being announced in https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image , `macos-latest` on `kivy/kivy` repo is already targeting `macos-14`, which is an Apple Silicon runner.

Therefore, our self-hosted `apple-silicon-m1` runner, after ~1.5 years of service will start the sunset phase.

However, now comes an additional issue: "How can we make sure to properly test things for Intel Macs?".

As ATM https://github.com/orgs/community/discussions/116568, is still unanswered, targeting `macos-13` for testing on an Intel runner looks like the best (free of charge) choice.
I guess the long-time alternative is `macos-latest-large`, which is a `macos-14` image that runs on Intel Macs, but is quite pricey for us.

What will be the future of `apple-silicon-m1` runner hardware?
- iOS Simulators?
- Android Emulators?

Similar PRs: https://github.com/kivy/kivy/pull/8713