### PR TITLE
Fix `E226` missing whitespace around arithmetic operator PEP8 failure

### DIFF
--- a/buildozer/targets/osx.py
+++ b/buildozer/targets/osx.py
@@ -64,7 +64,8 @@ class TargetOSX(Target):
             self.logger.info('Extracting and installing Kivy...')
             check_call(('hdiutil', 'attach', cwd + '/Kivy.dmg'))
             buildops.file_copytree(
-                '/Volumes/Kivy/Kivy.app', cwd+'/Kivy.app')
+                '/Volumes/Kivy/Kivy.app', cwd + '/Kivy.app'
+            )
 
     def ensure_kivyapp(self):
         self.logger.info('check if Kivy.app exists in local dir')


### PR DESCRIPTION
CI/CD pipeline started complaining about `E226 missing whitespace around arithmetic operator`.
This is a quick fix that fixes the issue.