### PR TITLE
Fix typo on `packaging.version` import statement

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -33,7 +33,7 @@ from sys import platform, executable
 from time import sleep
 import traceback
 
-import packaging
+import packaging.version
 import pexpect
 
 import buildozer.buildops as buildops


### PR DESCRIPTION
Oops, I've made a typo.

Unfortunately, CI/CD did not catch it as we're experiencing another issue which happens before this one gets triggered.