### PR TITLE
Ensure Java 17 is selected and available during build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,6 +17,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Setup environment
       run: |


### PR DESCRIPTION
`python-for-android` now requires Java 17 to be available and selected during build, as gradle requires it.

The CI is currently failing due to that.