### PR TITLE
Set Android min API to 24

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -112,7 +112,7 @@ fullscreen = 0
 #android.api = 31
 
 # (int) Minimum API your APK / AAB will support.
-#android.minapi = 21
+#android.minapi = 24
 
 # (int) Android SDK version to use
 #android.sdk = 20

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -11,7 +11,7 @@ from platform import uname
 WSL = 'microsoft' in uname()[2].lower()
 
 ANDROID_API = '31'
-ANDROID_MINAPI = '21'
+ANDROID_MINAPI = '24'
 APACHE_ANT_VERSION = '1.9.4'
 
 # This constant should *not* be updated, it is used only in the case


### PR DESCRIPTION
Avoids a very common error:
```
ImportError: cannot import name 'if_indextoname' from 'socket'
```