### PR TITLE
Re-add "all" to the list of valid orientations in default buildozer.spec

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -55,7 +55,7 @@ requirements = python3,kivy
 #icon.filename = %(source.dir)s/data/icon.png
 
 # (list) Supported orientations
-# Valid options are: landscape, portrait, portrait-reverse or landscape-reverse
+# Valid options are: landscape, portrait, portrait-reverse, landscape-reverse, or all
 orientation = portrait
 
 # (list) List of services to declare


### PR DESCRIPTION
Everything in the title :-) some users were confused by the absence of the option when they needed a multi-orientation app.