### PR TITLE
Explain Python version restrictions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ docker buildx build --platform=linux/amd64 -t kivy/buildozer .
 docker run --volume "$(pwd)":/home/user/hostcwd kivy/buildozer --version
 ```
 
+Note that the Docker image will preferentially try to use the `python` command from 
+`venv/bin/python`. If this command is symlinked to a Python version not present
+in the Docker image (currently, >python3.10), then all commands will fail.
+
 > [!WARNING]  
 > [DockerHub](https://hub.docker.com/) contains an obsolete Docker image for
 > Buildozer. It is deprecated. Build your own.


### PR DESCRIPTION
I note that there is already [a PR to support Ubuntu 24](https://github.com/kivy/buildozer/pull/1824), but hopefully this note will help guide others that run into issues in the meantime.