### PR TITLE
:memo: Fix broken documentation links

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,7 +21,7 @@ but it can be used independently - even with other GUI frameworks.
 
 Instructions on how to write your own recipes is available in the
 [Kivy for iOS](https://github.com/kivy/kivy-ios/) and
-[python-for-android documentation](https://python-for-android.readthedocs.io/en/latest/recipes/).
+[python-for-android documentation](https://python-for-android.readthedocs.io/en/latest/recipes.html).
 
 Instructions on how to test your own recipes from Buildozer is available in the
 [Buildozer Contribution Guidelines](CONTRIBUTING.md).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -117,7 +117,7 @@ Alternatively, the Android SDK license can be automatically accepted - see `buil
 python-for-android related errors
 """""""""""""""""""""""""""""""""
 See the dedicated `p4a troubleshooting documentation
-<https://python-for-android.readthedocs.io/en/latest/troubleshooting/>`_.
+<https://python-for-android.readthedocs.io/en/latest/troubleshooting.html>`_.
 
 
 Targeting IOS

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -27,7 +27,7 @@ who wants to use the same library.
 
 More instructions on how to write your own recipes is available in the
 `Kivy for iOS <https://github.com/kivy/kivy-ios/>`_ and
-`python-for-android documentation <https://python-for-android.readthedocs.io/en/latest/recipes/>`_.
+`python-for-android documentation <https://python-for-android.readthedocs.io/en/latest/recipes.html>`_.
 
 Instructions on how to test your own recipes from Buildozer is available in the
 `latest Buildozer Contribution Guidelines <https://github.com/kivy/buildozer/blob/master/CONTRIBUTING.md>`_.


### PR DESCRIPTION
Reported by the CI sphinx-build linkcheck command:
```
(recipes: line 28) broken https://python-for-android.readthedocs.io/en/latest/recipes/
(installation: line 119) broken https://python-for-android.readthedocs.io/en/latest/troubleshooting/
```