### PR TITLE
:construction_worker: Fix Coveralls parallel reporting

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -32,9 +32,23 @@ jobs:
       run: tox
     - name: Coveralls
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NAME: github-actions
+        COVERALLS_FLAG_NAME: python-${{ matrix.python }}-${{ matrix.os }}
+        COVERALLS_PARALLEL: true
       run: coveralls
+
+  Coveralls:
+    needs: Tests
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+    - name: Finished
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip install coveralls
+        coveralls --finish
 
   Docker:
     runs-on: ubuntu-latest
@@ -55,4 +69,3 @@ jobs:
       run: sphinx-build -b linkcheck docs/source docs/build
     - name: Generate documentation
       run: sphinx-build docs/source docs/build
-


### PR DESCRIPTION
Handle aggregated Coveralls reports using the `COVERALLS_PARALLEL` environment variable and the `--finish` flag. This prevents duplicate report submissions in the workflow matrix, which sometimes led to 422 "Unprocessable Entity" errors during upload:
```
Error running coveralls: Could not submit coverage: 422 Client Error:
Unprocessable Entity for url: https://coveralls.io/api/v1/jobs
```

Also updated the service name to `github-actions`, as suggested in:
- https://github.com/lemurheavy/coveralls-public/issues/1607#issuecomment-1000935999
- https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support