### PR TITLE
:construction_worker: Publish to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: kivy/buildozer
+  SHOULD_PUBLISH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: ${{ env.SHOULD_PUBLISH == 'true' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push Multi-platform Image
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ env.SHOULD_PUBLISH == 'true' }}
+          tags: ${{ env.IMAGE_NAME }}:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
+          cache-to: ${{ env.SHOULD_PUBLISH == 'true' && format('type=registry,ref={0}:latest,mode=max', env.IMAGE_NAME) || '' }}
+      - name: Local Build for Testing
+        uses: docker/build-push-action@v6
+        with:
+          # Load image into local Docker daemon
+          load: true
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_NAME }}:latest
+      # Run the locally built image to test it
+      - name: Docker run
+        run: docker run ${{ env.IMAGE_NAME }} --version
+
+  update-readme:
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: peter-evans/dockerhub-description@v4
+        if: ${{ env.SHOULD_PUBLISH == 'true' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          readme-filepath: README.md

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ build dependencies. For more information, see
 [![Android](https://github.com/kivy/buildozer/workflows/Android/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AAndroid)
 [![iOS](https://github.com/kivy/buildozer/workflows/iOS/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AiOS)
 [![Coverage Status](https://coveralls.io/repos/github/kivy/buildozer/badge.svg)](https://coveralls.io/github/kivy/buildozer)
+[![Docker](https://github.com/kivy/buildozer/actions/workflows/docker.yml/badge.svg)](https://github.com/kivy/buildozer/actions/workflows/docker.yml)
 
 
 ## Installation
@@ -68,7 +69,7 @@ docker build --tag=kivy/buildozer .
 For macOS, build with:
 
 ```bash
-docker buildx build --platform=linux/amd64 -t kivy/buildozer .
+docker buildx build --platform=linux/amd64 --tag=kivy/buildozer .
 ```
 
 - Run with:
@@ -76,10 +77,6 @@ docker buildx build --platform=linux/amd64 -t kivy/buildozer .
 ```bash
 docker run --volume "$(pwd)":/home/user/hostcwd kivy/buildozer --version
 ```
-
-> [!WARNING]  
-> [DockerHub](https://hub.docker.com/) contains an obsolete Docker image for
-> Buildozer. It is deprecated. Build your own.
 
 ### Example Build with Caching
 - Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
@@ -94,9 +91,6 @@ docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcw
 Use [ArtemSBulgakov/buildozer-action@v1](https://github.com/ArtemSBulgakov/buildozer-action)
 to build your packages automatically on push or pull request.
 See [full workflow example](https://github.com/ArtemSBulgakov/buildozer-action#full-workflow).
-
-> [!WARNING]  
-> This GitHub action may use an obsolete version of Buildozer; use with caution.
 
 ## Usage
 


### PR DESCRIPTION
- multi-platform build using buildx
- push to DockerHub and update DockerHub README on push to master or tagging
- use the Docker Hub registry for caching image layers to speed up builds