### PR TITLE
Android support display cutout

### DIFF
--- a/buildozer/default.spec
+++ b/buildozer/default.spec
@@ -318,6 +318,12 @@ android.allow_backup = True
 # (str) The format used to package the app for debug mode (apk or aar).
 # android.debug_artifact = apk
 
+# (str) A display cutout is an area on some devices that extends into the display surface.
+# It allows for an edge-to-edge experience while providing space for important sensors on the front of the device.
+# Available options for Android API >= 28 are "default, shortEdges, never" and defaults to never.
+# Android documentation: https://developer.android.com/develop/ui/views/layout/display-cutout
+#android.display_cutout = never
+
 #
 # Python for android (p4a) specific
 #

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -872,7 +872,7 @@ class TargetAndroid(Target):
 
         # Enable display-cutout for Android devices
         display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never').lower()
-        if display_cutout in {'default', 'shortedges'}:
+        if display_cutout in {'default', 'shortedges', 'shortEdges'}:
             if display_cutout == 'shortedges':
                 display_cutout = 'shortEdges'
             cmd.append("--display-cutout={}".format(display_cutout))

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -870,6 +870,17 @@ class TargetAndroid(Target):
         if self.buildozer.config.getbooldefault('app', 'android.home_app', False):
             cmd.append("--home-app")
 
+        # Enable display-cutout for Android devices
+        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never').lower()
+        if display_cutout in {'default', 'shortedges', 'never'}:
+            if display_cutout == 'shortedges':
+                display_cutout = 'shortEdges'
+            cmd.append("--display-cutout={}".format(display_cutout))
+        else:
+            raise BuildozerException(
+                "You have stated the wrong option for android.display_cutout. "
+                "One of the following options are required: 'default', 'shortEdges' and 'never'.")
+
         # support for recipes in a local directory within the project
         if local_recipes:
             cmd.append('--local-recipes')

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -872,14 +872,10 @@ class TargetAndroid(Target):
 
         # Enable display-cutout for Android devices
         display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never').lower()
-        if display_cutout in {'default', 'shortedges', 'never'}:
+        if display_cutout in {'default', 'shortedges'}:
             if display_cutout == 'shortedges':
                 display_cutout = 'shortEdges'
             cmd.append("--display-cutout={}".format(display_cutout))
-        else:
-            raise BuildozerException(
-                "You have stated the wrong option for android.display_cutout. "
-                "One of the following options are required: 'default', 'shortEdges' and 'never'.")
 
         # support for recipes in a local directory within the project
         if local_recipes:

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -871,7 +871,7 @@ class TargetAndroid(Target):
             cmd.append("--home-app")
 
         # Enable display-cutout for Android devices
-        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never').lower()
+        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never')
         if display_cutout in {'default', 'shortedges', 'shortEdges'}:
             if display_cutout == 'shortedges':
                 display_cutout = 'shortEdges'

--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -871,8 +871,8 @@ class TargetAndroid(Target):
             cmd.append("--home-app")
 
         # Enable display-cutout for Android devices
-        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never')
-        if display_cutout in {'default', 'shortedges', 'shortEdges'}:
+        display_cutout = self.buildozer.config.getdefault('app', 'android.display_cutout', 'never').lower()
+        if display_cutout in {'default', 'shortedges'}:
             if display_cutout == 'shortedges':
                 display_cutout = 'shortEdges'
             cmd.append("--display-cutout={}".format(display_cutout))

--- a/docs/source/specifications.rst
+++ b/docs/source/specifications.rst
@@ -145,3 +145,6 @@ Section [app]
 
   Defaults to false, your application will be listed as a Home App (launcher app) if true.
 
+- `display_cutout`: String, display-cutout mode to be used.
+
+  Defaults to `never`. Application will render around the cutout (notch) if set to either `default`, `shortEdges`.


### PR DESCRIPTION
This PR enables display-cutout for Android devices. It's just a hook for the merged [p4a-PR](https://github.com/kivy/python-for-android/pull/2969) in order to use this option with Buildozer.
Everything is documented.