### PR TITLE
Android sdkmanager proxy config

### DIFF
--- a/buildozer/targets/android.py
+++ b/buildozer/targets/android.py
@@ -205,11 +205,9 @@ class TargetAndroid(Target):
         # Sdkmanager only supports proxy types `http` and `socks`, so even if proxy url is https,
         # only pass host and port with `http` type.
         for key in ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy']:
-            proxy = os.environ.get(key)
             try:
-                host, port = proxy.split(':')[-2:]
-                host = host.strip('/')
-                command.extend(['--proxy=http', f'--proxy_host={host}', f'--proxy_port={port}'])
+                host, port = os.environ.get(key).split(':')[-2:]
+                command.extend(['--proxy=http', f'--proxy_host={host.strip("/")}', f'--proxy_port={port}'])
                 break
             except:
                 pass


### PR DESCRIPTION
This PR configures android sdkmanager to use system proxy info from env var http_proxy, which is needed for buildozer android to work on corporate networks with a proxy in place. Related to #142 but this seems like a simpler implementation that leverages env vars that are typically already defined while working in a corporate proxy setting.