### PR TITLE
Buildozer install docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,6 +6,8 @@ Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for
 you, but it doesn't cover every situation.
 
+Buildozer runs on Linux and Macos, Windows users must install WSL to use Linux.
+
 Targeting Android
 -----------------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,13 +2,15 @@ Installation
 ============
 
 Buildozer can be installed on Linux or Macos, Windows users must install WSL to use Linux. 
-Target platforms are Android and iOS, iOS is only available for Buildozer MacOS installs. 
+Target platforms are Android and iOS, iOS is only available for MacOS installs. 
 After Buildozer installation read the Quickstart documentation.
 
+This page contains install instructions for targeting Android or iOS. The Android section contains instructions 
+for installing Buildozer on Ubuntu or on MacOS, also there are special notes for WSL users. Other Linux OS can 
+be used (for example Colab) but there are no instructions. The iOS section 
+contains instructions for installing kivy-ios on MacOS.
+
 Buildozer is tested on Python 3.8 and above. 
-Depending the platform you want to target, you might need more tools installed.
-Buildozer tries to give you hints or tries to install few things for
-you, but it doesn't cover every situation.
 
 Targeting Android
 -----------------
@@ -37,11 +39,12 @@ Note that the Rust on-screen instructions specify to add::
 
     . "$HOME/.cargo/env"
 
-to ~/.bashrc, and to open a new shell. Note the leading period above.
+to ~/.bashrc, and to open a new shell. The leading period in the line above above is important.
 
 Activate an existing Python virtual environment, or create and activate a new Python virtual environment. 
 Python 3.12 defaults to requiring a virtual environment::
 
+    cd
     virtualenv venv
     source venv/bin/activate
 
@@ -70,21 +73,15 @@ Then install the buildozer project with::
 
     pip3 install --user --upgrade buildozer
 
-Install on Windows
-~~~~~~~~~~~~~~~~~~
+Notes for WSL users
+~~~~~~~~~~~~~~~~~~~
 
-To use Buildozer on Windows, you need first to enable Windows Subsystem for Linux (WSL) and
-`install a Linux distribution <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+Legacy WSL1 users must upgrade to WSL2. WSL1 has a known fatal issue.
 
-These instructions were tested with WSL2 with Ubuntu 20.04, 22.04, and 24.04. WSL1 has a known fatal issue.
+Copy your Kivy project directory from the Windows file system (usually under /mnt/c) to the WSL file system (under ~).
 
-After installing WSL and Ubuntu on your Windows machine, open Ubuntu, follow the instructions above,
-and restart your WSL terminal to enable the path change.
-
-Copy your Kivy project directory from the Windows partition (under /mnt/c) to the WSL partition (under ~).
-
-It is important to use the WSL partition. Builds are about 5 times faster than the Windows partition, 
-and using an NTFS partition on a Linux system may cause some Python packages to behave as if they are 
+It is important to build on the WSL file system. Builds are about 5 times faster than the Windows file system, 
+and using an NTFS formatted disk on a Linux system may cause some Python packages to incorrectly behave as if they are 
 configured for Windows.
 
 For debugging, WSL does not have direct access to USB. Copy the .apk file to the Windows partition and run ADB

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Buildozer is tested on Python 3.9 and above.
+Buildozer is tested on Python 3.8 and above.
 Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for
 you, but it doesn't cover every situation.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,21 +1,24 @@
 Installation
 ============
 
-Buildozer is tested on Python 3.8 and above.
+Buildozer can be installed on Linux or Macos, Windows users must install WSL to use Linux. 
+Target platforms are Android and iOS, iOS is only available for Buildozer MacOS installs. 
+After Buildozer installation read the Quickstart documentation.
+
+Buildozer is tested on Python 3.8 and above. 
 Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for
 you, but it doesn't cover every situation.
 
-Buildozer runs on Linux and Macos, Windows users must install WSL to use Linux.
-
 Targeting Android
 -----------------
 
-Android on Ubuntu 24.04
+Install on Ubuntu 24.04
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Install the system packages on which a Buildozer build may depend::
 
+    sudo apt update
     sudo apt install -y git zip unzip openjdk-17-jdk python3-pip \
     python3-virtualenv autoconf libtool pkg-config zlib1g-dev \
     libncurses5-dev libncursesw5-dev libtinfo6 cmake libffi-dev \
@@ -34,9 +37,10 @@ Note that the Rust on-screen instructions specify to add::
 
     . "$HOME/.cargo/env"
 
-to ~/.bashrc, and to open a new shell.
+to ~/.bashrc, and to open a new shell. Note the leading period above.
 
-Activate an existing Python virtual environment, or create and activate a new Python virtual environment. This is a Python 3.12 requirement::
+Activate an existing Python virtual environment, or create and activate a new Python virtual environment. 
+This is a Python 3.12 requirement::
 
     virtualenv venv
     source venv/bin/activate
@@ -46,18 +50,15 @@ Install Buildozer and it's required Python packages::
     pip install buildozer, setuptools, cython==0.29.34
 
 
-Android on Ubuntu 20.04 and 22.04 (64bit)
+Install on Ubuntu 20.04 and 22.04 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-  Later versions of Ubuntu are expected to work. However only the latest
-  `Long Term Support (LTS) release <https://ubuntu.com/about/release-cycle>`_
-  is regularly tested.
-
-Additional installation required to support Android::
+Install the system packages on which a Buildozer build may depend::
 
     sudo apt update
-    sudo apt install -y git zip unzip openjdk-17-jdk python3-pip autoconf libtool pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev libssl-dev automake
+    sudo apt install -y git zip unzip openjdk-17-jdk python3-pip autoconf libtool \
+    pkg-config zlib1g-dev libncurses5-dev libncursesw5-dev libtinfo5 cmake libffi-dev \
+    libssl-dev automake
 
     # add the following line at the end of your ~/.bashrc file
     export PATH=$PATH:~/.local/bin/
@@ -69,8 +70,8 @@ Then install the buildozer project with::
 
     pip3 install --user --upgrade buildozer
 
-Buildozer on Windows 10 or 11
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install on Windows
+~~~~~~~~~~~~~~~~~~
 
 To use Buildozer on Windows, you need first to enable Windows Subsystem for Linux (WSL) and
 `install a Linux distribution <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
@@ -82,7 +83,9 @@ and restart your WSL terminal to enable the path change.
 
 Copy your Kivy project directory from the Windows partition (under /mnt/c) to the WSL partition (under ~).
 
-It is important to use the WSL partition. Builds are about 5 times faster than the Windows partition, and using an NTFS partition on a Linux system may lead to obscure Python issues.
+It is important to use the WSL partition. Builds are about 5 times faster than the Windows partition, 
+and using an NTFS partition on a Linux system may cause some Python packages to behave as if they are 
+configured for Windows.
 
 For debugging, WSL does not have direct access to USB. Copy the .apk file to the Windows partition and run ADB
 (Android Debug Bridge) from a Windows prompt. ADB is part of Android Studio, if you do not have this installed
@@ -93,19 +96,8 @@ you can install just the platform tools which also contain ADB.
 
 - Unzip the downloaded file to a new folder. For example, `C:\\platform-tools\\`
 
-Before Using Buildozer
-~~~~~~~~~~~~~~~~~~~~~~
 
-
-If you wish, clone your code to a new folder where the build process will run.
-
-You don't need to create a virtualenv for your code requirements. But just add these requirements to a configuration
-file called `buildozer.spec` as you will see in the following sections.
-
-Before running Buildozer in your code folder, remember to go into the Buildozer folder and activate the Buildozer
-virtualenv.
-
-Android on macOS
+Install on macOS
 ~~~~~~~~~~~~~~~~
 
 Additional installation required to support macOS::
@@ -113,28 +105,13 @@ Additional installation required to support macOS::
     python3 -m pip install --user --upgrade buildozer # the --user should be removed if you do this in a venv
 
 
-TroubleShooting
-~~~~~~~~~~~~~~~
-
-Buildozer stuck on "Installing/updating SDK platform tools if necessary"
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Press "y" then enter to continue, the license acceptance system is silently waiting for your input
-
+Install TroubleShooting
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Aidl not found, please install it.
 """"""""""""""""""""""""""""""""""
 
-Buildozer didn't install a necessary package
-
-::
-
-    ~/.buildozer/android/platform/android-sdk/tools/bin/sdkmanager "build-tools;29.0.0"
-
-Then press "y" then enter to accept the license.
-
-Alternatively, the Android SDK license can be automatically accepted - see `build.spec` for details.
-
+Delete "~/.buildozer" and run buildozer again. You must type 'y' to accept each Google license agreement.
 
 python-for-android related errors
 """""""""""""""""""""""""""""""""

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -24,10 +24,15 @@ If there are multiple versions of Java installed, select `*17-openjdk*` using::
     sudo update-alternatives --config java
     sudo update-alternatives --config javac
 
-Install Rust as some features depend on Rust. Accept the default option.
-Note that the Rust on-screen instructions specify to add `. "$HOME/.cargo/env"` to `~/.bashrc`, and to open a new shell::
+Install Rust, and accept the default option::
 
     curl https://sh.rustup.rs -sSf | sh
+
+Note that the Rust on-screen instructions specify to add::
+
+    . "$HOME/.cargo/env"
+
+to ~/.bashrc, and to open a new shell.
 
 Activate an existing Python virtual environment, or create and activate a new Python virtual environment. This is a Python 3.12 requirement::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -40,7 +40,7 @@ Note that the Rust on-screen instructions specify to add::
 to ~/.bashrc, and to open a new shell. Note the leading period above.
 
 Activate an existing Python virtual environment, or create and activate a new Python virtual environment. 
-This is a Python 3.12 requirement::
+Python 3.12 defaults to requiring a virtual environment::
 
     virtualenv venv
     source venv/bin/activate

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,26 +1,43 @@
 Installation
 ============
 
-Buildozer is tested on Python 3.8 and above.
+Buildozer is tested on Python 3.9 and above.
 Depending the platform you want to target, you might need more tools installed.
 Buildozer tries to give you hints or tries to install few things for
 you, but it doesn't cover every situation.
 
-First, install the buildozer project.
-
-The most-recently released version can be installed with::
-
-    pip install --user --upgrade buildozer
-
-Add the `--user` option if you are not using a virtual environment (not recommended).
-
-If you would like to install the latest version still under development::
-
-    pip install https://github.com/kivy/buildozer/archive/master.zip
-
-
 Targeting Android
 -----------------
+
+Android on Ubuntu 24.04
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Install the system packages on which a Buildozer build may depend::
+
+    sudo apt install -y git zip unzip openjdk-17-jdk python3-pip \
+    python3-virtualenv autoconf libtool pkg-config zlib1g-dev \
+    libncurses5-dev libncursesw5-dev libtinfo6 cmake libffi-dev \
+    libssl-dev automake autopoint gettext
+
+If there are multiple versions of Java installed, select `*17-openjdk*` using::
+
+    sudo update-alternatives --config java
+    sudo update-alternatives --config javac
+
+Install Rust as some features depend on Rust. Accept the default option.
+Note that the Rust on-screen instructions specify to add `. "$HOME/.cargo/env"` to `~/.bashrc`, and to open a new shell::
+
+    curl https://sh.rustup.rs -sSf | sh
+
+Activate an existing Python virtual environment, or create and activate a new Python virtual environment. This is a Python 3.12 requirement::
+
+    virtualenv venv
+    source venv/bin/activate
+
+Install Buildozer and it's required Python packages::
+
+    pip install buildozer, setuptools, cython==0.29.34
+
 
 Android on Ubuntu 20.04 and 22.04 (64bit)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,23 +62,20 @@ Then install the buildozer project with::
 
     pip3 install --user --upgrade buildozer
 
-
-Android on Windows 10 or 11
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Buildozer on Windows 10 or 11
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use Buildozer on Windows, you need first to enable Windows Subsystem for Linux (WSL) and
 `install a Linux distribution <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
 
-These instructions were tested with WSL 1 and Ubuntu 18.04 LTS, and WSL2 with Ubuntu 20.04 and 22.04.
+These instructions were tested with WSL2 with Ubuntu 20.04, 22.04, and 24.04. WSL1 has a known fatal issue.
 
-After installing WSL and Ubuntu on your Windows machine, open Ubuntu, run the commands listed in the previous section,
+After installing WSL and Ubuntu on your Windows machine, open Ubuntu, follow the instructions above,
 and restart your WSL terminal to enable the path change.
 
-Copy your Kivy project directory from the Windows partition to the WSL partition.
+Copy your Kivy project directory from the Windows partition (under /mnt/c) to the WSL partition (under ~).
 
-.. warning::
-    It is important to use the WSL partition. The Android SDK for Linux does not work on Windows' NTFS drives.
-    This will lead to obscure failures.
+It is important to use the WSL partition. Builds are about 5 times faster than the Windows partition, and using an NTFS partition on a Linux system may lead to obscure Python issues.
 
 For debugging, WSL does not have direct access to USB. Copy the .apk file to the Windows partition and run ADB
 (Android Debug Bridge) from a Windows prompt. ADB is part of Android Studio, if you do not have this installed
@@ -74,6 +88,7 @@ you can install just the platform tools which also contain ADB.
 
 Before Using Buildozer
 ~~~~~~~~~~~~~~~~~~~~~~
+
 
 If you wish, clone your code to a new folder where the build process will run.
 


### PR DESCRIPTION
Adds install instructions for Ubuntu 24.04

Cleans up so the page looks coherent, rather than a patchwork of incremental changes. 

