### PR TITLE
:hammer: Fix Docker permission errors with bind mounts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,9 @@ jobs:
           tags: ${{ env.DOCKERHUB_IMAGE }}:latest
       # Run the locally built image to test it
       - name: Docker run
-        run: docker run ${{ env.DOCKERHUB_IMAGE }} --version
+        run: |
+          docker run ${{ env.DOCKERHUB_IMAGE }} --version
+          docker run --rm --volume "$PWD":/home/user/hostcwd ${{ env.DOCKERHUB_IMAGE }} init
 
   update-readme:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Requirements
-      run: pip install -U sphinx sphinxawesome_theme
+      run: pip install --upgrade sphinx sphinxawesome_theme
     - name: Check links
       run: sphinx-build -b linkcheck docs/source docs/build
     - name: Generate documentation

--- a/README.md
+++ b/README.md
@@ -75,14 +75,19 @@ docker buildx build --platform=linux/amd64 --tag=kivy/buildozer .
 - Run with:
 
 ```bash
-docker run --volume "$(pwd)":/home/user/hostcwd kivy/buildozer --version
+docker run --interactive --tty --rm \
+    --volume "$PWD":/home/user/hostcwd \
+   kivy/buildozer --version
 ```
 
 ### Example Build with Caching
 - Build and keep downloaded SDK and NDK in `~/.buildozer` directory: 
 
 ```bash
-docker run -v $HOME/.buildozer:/home/user/.buildozer -v $(pwd):/home/user/hostcwd kivy/buildozer android debug
+docker run --interactive --tty --rm \
+    --volume "$HOME/.buildozer":/home/user/.buildozer \
+    --volume "$PWD":/home/user/hostcwd \
+    kivy/buildozer android debug
 ```
 
 The image is published to both Docker Hub and GitHub Container Registry and can be pulled from both:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Map container user to host UID/GID (from /home/user/hostcwd) so writes to the
+# bind-mounted project work. Then exec Buildozer from the venv as that user.
+
+set -euo pipefail
+
+DEFAULT_USER_NAME="user"
+DEFAULT_USER_HOME="/home/$DEFAULT_USER_NAME"
+
+# Read UID/GID from bind mount; default to 1000:1000 if absent
+HOST_UID="$(stat -c %u "$DEFAULT_USER_HOME/hostcwd" 2>/dev/null || echo 1000)"
+HOST_GID="$(stat -c %g "$DEFAULT_USER_HOME/hostcwd" 2>/dev/null || echo 1000)"
+
+# Create group with host GID if it doesn't exist
+if ! getent group $HOST_GID > /dev/null 2>&1; then
+    groupadd --gid $HOST_GID hostgroup
+fi
+
+# Check if UID already exists
+if getent passwd $HOST_UID > /dev/null 2>&1; then
+    # UID exists, get the existing username
+    USER_NAME="$(getent passwd $HOST_UID | cut -d: -f1)"
+else
+    # UID doesn't exist, create new user
+    USER_NAME="$DEFAULT_USER_NAME"
+    useradd --uid $HOST_UID --gid $HOST_GID --home "$DEFAULT_USER_HOME" --shell /bin/bash --no-create-home "$DEFAULT_USER_NAME"
+fi
+
+# Ensure home directory and venv ownership
+chown --recursive $HOST_UID:$HOST_GID "$DEFAULT_USER_HOME"
+
+# Switch to the user and execute buildozer
+BUILDOZER="$DEFAULT_USER_HOME/.venv/bin/buildozer"
+exec sudo --preserve-env --user "$USER_NAME" HOME="$DEFAULT_USER_HOME" PATH="$DEFAULT_USER_HOME/.venv/bin:$PATH" -- "$BUILDOZER" "$@"


### PR DESCRIPTION
Bind-mounted project dirs failed on `buildozer init` with permission denied because container UID/GID didn't match the host. Add a lean entrypoint that maps the container user to the host UID/GID
 execs buildozer, fixing writes to `/home/user/hostcwd`.

See command used and error output:
```
docker run --volume "$(pwd)":/home/user/hostcwd kivy/buildozer init
Traceback (most recent call last):
  File "/home/user/.venv/bin/buildozer", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/.venv/lib/python3.12/site-packages/buildozer/scripts/client.py", line 16, in main
    Buildozer().run_command(sys.argv[1:])
  File "/home/user/.venv/lib/python3.12/site-packages/buildozer/__init__.py", line 672, in run_command
    getattr(self, cmd)(*args)
  File "/home/user/.venv/lib/python3.12/site-packages/buildozer/__init__.py", line 711, in cmd_init
    buildops.file_copy(join(dirname(__file__), 'default.spec'), 'buildozer.spec')
  File "/home/user/.venv/lib/python3.12/site-packages/buildozer/buildops.py", line 108, in file_copy
    copyfile(source, target)
  File "/usr/lib/python3.12/shutil.py", line 262, in copyfile
    with open(dst, 'wb') as fdst:
         ^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'buildozer.spec'
```