### PR TITLE
:hammer: Remove BuildKit registry cache, fixes #1945

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,15 +44,12 @@ jobs:
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.GHCR_IMAGE }}:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:latest
-          cache-to: ${{ env.SHOULD_PUBLISH == 'true' && format('type=registry,ref={0}:latest,mode=max', env.DOCKERHUB_IMAGE) || '' }}
 
       - name: Local Build for Testing
         uses: docker/build-push-action@v6
         with:
           # Load image into local Docker daemon
           load: true
-          cache-from: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:latest
           tags: ${{ env.DOCKERHUB_IMAGE }}:latest
       # Run the locally built image to test it
       - name: Docker run


### PR DESCRIPTION
The BuildKit cache-to configuration was writing cache metadata to Docker Hub with media type application/vnd.buildkit.cacheconfig.v0, which causes pull errors on modern Docker clients (v28.3.3+):

  "unsupported media type application/vnd.buildkit.cacheconfig.v0"

Removed cache-from and cache-to parameters from the Docker workflow to publish clean images without BuildKit cache metadata. This fixes Docker Hub pulls while maintaining multi-platform builds and dual registry publishing (Docker Hub + GHCR).

Build times may increase slightly without registry caching, but this is an acceptable trade-off for client compatibility.