### PR TITLE
:bug: Fix Docker pip --user install error in virtualenv

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   DOCKERHUB_IMAGE: kivy/buildozer
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  SHOULD_PUBLISH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
+  GHCR_IMAGE: ghcr.io/kivy/buildozer
+  SHOULD_PUBLISH: ${{ github.repository_owner == 'kivy' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,8 @@ COPY . ${SRC_DIR}
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # installs buildozer and dependencies from a virtual environment
-ENV PATH="${HOME_DIR}/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="${HOME_DIR}/.venv"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN pip install --upgrade "Cython<3.0" wheel pip ${SRC_DIR}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Set VIRTUAL_ENV environment variable in Dockerfile to fix the error when building Android apps. The error was:
```
Can not perform a '--user' install. User site-packages are not
visible in this virtualenv
```

The Docker container creates a virtualenv at /home/user/.venv but was only setting PATH, not VIRTUAL_ENV. This caused buildozer's virtualenv detection logic to incorrectly add --user flag to pip.

Also restrict Docker image publishing to upstream repository only by adding repository_owner check to SHOULD_PUBLISH condition. This prevents forks from attempting to publish to container registries, which would fail due to missing credentials and GHCR's lowercase requirement for repository names.

Fixes #1977