### PR TITLE
docs(installation): drop commas from pip install example (and 'it's' -> 'its')

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -58,9 +58,9 @@ Python 3.12 defaults to requiring a virtual environment::
     virtualenv venv_p4a_master
     source venv_p4a_master/bin/activate
 
-Install Buildozer and it's required Python packages::
+Install Buildozer and its required Python packages::
 
-    pip install buildozer, setuptools, cython==0.29.34
+    pip install buildozer setuptools cython==0.29.34
 
 To use p4a develop
 """"""""""""""""""
@@ -73,7 +73,7 @@ Create and activate a new Python 3.14 virtual environment::
     python3.14 -m venv venv_p4a_develop
     source venv_p4a_develop/bin/activate
 
-Install the master version of Buildozer and it's required Python packages::
+Install the master version of Buildozer and its required Python packages::
 
     pip install git+https://github.com/kivy/buildozer
     pip install legacy-cgi setuptools cython==0.29.34


### PR DESCRIPTION
## Summary

\`docs/source/installation.rst\` line 63 instructs:

\`\`\`
pip install buildozer, setuptools, cython==0.29.34
\`\`\`

Running that as printed errors out with:

\`\`\`
ERROR: Invalid requirement: 'buildozer,': Expected semicolon (after name with no version specifier) or end
\`\`\`

Every other \`pip install\` example in the same file is whitespace-separated (\`pip install legacy-cgi setuptools cython==0.29.34\`). Fixing the errant commas so copy-pasting actually installs.

Also fixed adjacent \`it's required Python packages\` -> \`its required Python packages\` (two occurrences, lines 61 and 76) while in the file.

Closes #2001

## Testing

Documentation-only change. Verified:
- \`pip install buildozer setuptools cython==0.29.34\` is the form pip expects;
- the surrounding examples in \`installation.rst\` already use whitespace-separated requirements.