### PR TITLE
Docs: Pin `sphinxawesome_theme` to 5.3.2

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Requirements
-      run: pip install --upgrade sphinx sphinxawesome_theme
+      run: pip install --upgrade sphinx sphinxawesome_theme==5.3.2
     - name: Check links
       run: sphinx-build -b linkcheck docs/source docs/build
     - name: Generate documentation

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Requirements
-      run: pip install --upgrade sphinx sphinxawesome_theme==5.3.2
+      run: pip install --upgrade ".[docs]"
     - name: Check links
       run: sphinx-build -b linkcheck docs/source docs/build
     - name: Generate documentation

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     ],
     extras_require={
         'test': ['pytest'],
-        'docs': ['sphinx', 'sphinxawesome_theme==5.3.2'],
+        'docs': ['sphinx', 'sphinxawesome_theme>=5.3,<6'],
         'ios': ['kivy-ios'],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     ],
     extras_require={
         'test': ['pytest'],
-        'docs': ['sphinx', 'sphinxawesome_theme'],
+        'docs': ['sphinx', 'sphinxawesome_theme==5.3.2'],
         'ios': ['kivy-ios'],
     },
     classifiers=[


### PR DESCRIPTION
Pinning sphinxawesome_theme version because of this!!
<img width="970" height="635" alt="image" src="https://github.com/user-attachments/assets/a5b6b676-2429-4397-9c79-1413d64bb378" />

After pinning it works normally: (https://buildozer-fork.readthedocs.io/en/latest/installation/)
<img width="936" height="614" alt="image" src="https://github.com/user-attachments/assets/e390ce80-1886-4eeb-97ff-87e736162813" />
