### PR TITLE
:bug: Fix README badges and align Python classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ build dependencies. For more information, see
 [![GitHub contributors](https://img.shields.io/github/contributors-anon/kivy/buildozer)](https://github.com/kivy/buildozer/graphs/contributors)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
-![PyPI - Version](https://img.shields.io/pypi/v/buildozer)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/buildozer)
+[![PyPI - Version](https://img.shields.io/pypi/v/buildozer)](https://pypi.org/project/buildozer/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/buildozer)](https://pypi.org/project/buildozer/)
 
 [![Tests](https://github.com/kivy/buildozer/workflows/Tests/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3ATests)
-[![Android](https://github.com/kivy/buildozer/workflows/Android/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AAndroid)
+[![Android](https://github.com/kivy/buildozer/actions/workflows/android.yml/badge.svg)](https://github.com/kivy/buildozer/actions/workflows/android.yml)
 [![iOS](https://github.com/kivy/buildozer/workflows/iOS/badge.svg)](https://github.com/kivy/buildozer/actions?query=workflow%3AiOS)
 [![Coverage Status](https://coveralls.io/repos/github/kivy/buildozer/badge.svg)](https://coveralls.io/github/kivy/buildozer)
 [![Docker](https://github.com/kivy/buildozer/actions/workflows/docker.yml/badge.svg)](https://github.com/kivy/buildozer/actions/workflows/docker.yml)

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'docs': ['sphinx', 'sphinxawesome_theme>=5.3,<6'],
         'ios': ['kivy-ios'],
     },
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -95,6 +96,9 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Wrap PyPI Version and Python Version badges in links to the project's PyPI page; previously they were bare images so clicking them navigated to the badge image instead of PyPI.

Switch the Android badge to the file-based URL form, matching the Docker badge. The legacy name-based URL referenced "Android" but the workflow was renamed to "Android Integration" in #1686, leaving the badge as a 404.

Add python_requires=">=3.8" and extend setup.py classifiers through Python 3.14 to match the CI matrix. shields.io reads classifiers from PyPI on each release, so the pyversions badge will reflect actual support on the next release.