### PR TITLE
:white_check_mark: Cover Target base class and Buildozer helpers

### DIFF
--- a/buildozer/target.py
+++ b/buildozer/target.py
@@ -107,39 +107,47 @@ class Target:
         self.build_mode = 'debug'
         self.buildozer.build()
 
-    def cmd_release(self, *args):
+    def _check_package_domain(self, domain, override_env_var, body_lines):
+        if self.buildozer.config.get("app", "package.domain") != domain:
+            return
         error = self.logger.error
+        error("")
+        error("ERROR: Trying to release a package that starts with {}".format(domain))
+        error("")
+        for line in body_lines:
+            error(line)
+        error("")
+        if override_env_var not in os.environ:
+            exit(1)
+
+    def cmd_release(self, *args):
         self.buildozer.prepare_for_build()
-        if self.buildozer.config.get("app", "package.domain") == "org.test":
-            error("")
-            error("ERROR: Trying to release a package that starts with org.test")
-            error("")
-            error("The package.domain org.test is, as the name intended, a test.")
-            error("Once you published an application with org.test,")
-            error("you cannot change it, it will be part of the identifier")
-            error("for Google Play / App Store / etc.")
-            error("")
-            error("So change package.domain to anything else.")
-            error("")
-            error("If you messed up before, set the environment variable to force the build:")
-            error("export BUILDOZER_ALLOW_ORG_TEST_DOMAIN=1")
-            error("")
-            if "BUILDOZER_ALLOW_ORG_TEST_DOMAIN" not in os.environ:
-                exit(1)
-
-        if self.buildozer.config.get("app", "package.domain") == "org.kivy":
-            error("")
-            error("ERROR: Trying to release a package that starts with org.kivy")
-            error("")
-            error("The package.domain org.kivy is reserved for the Kivy official")
-            error("applications. Please use your own domain.")
-            error("")
-            error("If you are a Kivy developer, add an export in your shell")
-            error("export BUILDOZER_ALLOW_KIVY_ORG_DOMAIN=1")
-            error("")
-            if "BUILDOZER_ALLOW_KIVY_ORG_DOMAIN" not in os.environ:
-                exit(1)
-
+        self._check_package_domain(
+            "org.test",
+            "BUILDOZER_ALLOW_ORG_TEST_DOMAIN",
+            [
+                "The package.domain org.test is, as the name intended, a test.",
+                "Once you published an application with org.test,",
+                "you cannot change it, it will be part of the identifier",
+                "for Google Play / App Store / etc.",
+                "",
+                "So change package.domain to anything else.",
+                "",
+                "If you messed up before, set the environment variable to force the build:",
+                "export BUILDOZER_ALLOW_ORG_TEST_DOMAIN=1",
+            ],
+        )
+        self._check_package_domain(
+            "org.kivy",
+            "BUILDOZER_ALLOW_KIVY_ORG_DOMAIN",
+            [
+                "The package.domain org.kivy is reserved for the Kivy official",
+                "applications. Please use your own domain.",
+                "",
+                "If you are a Kivy developer, add an export in your shell",
+                "export BUILDOZER_ALLOW_KIVY_ORG_DOMAIN=1",
+            ],
+        )
         self.build_mode = 'release'
         self.buildozer.build()
 

--- a/tests/test_buildozer.py
+++ b/tests/test_buildozer.py
@@ -3,6 +3,10 @@ import os
 import codecs
 import shutil
 import unittest
+import warnings
+
+import pytest
+
 import buildozer as buildozer_module
 from buildozer import Buildozer
 from io import StringIO
@@ -183,6 +187,225 @@ class TestBuildozer(unittest.TestCase):
         mock_open.assert_called_once()
 
 
+class TestBuildozerHelpers:
+    """Tests for pure-helper methods on the Buildozer class.
+
+    These methods either manipulate strings/lists, validate config, or
+    compose paths; they perform no subprocess, network, or filesystem I/O
+    (beyond os.path joins). A non-existent specfile keeps Buildozer.__init__
+    from invoking check_configuration_tokens during construction so each
+    test can drive the helper directly with a hand-built config.
+    """
+
+    SPECFILE = '/tmp/buildozer_helpers_does_not_exist.spec'
+
+    def _new_buildozer(self):
+        buildozer = Buildozer(self.SPECFILE)
+        config = buildozer.config
+        config.add_section('app')
+        config.set('app', 'title', 'Test App')
+        config.set('app', 'source.dir', '.')
+        config.set('app', 'package.name', 'testapp')
+        config.set('app', 'version', '0.1')
+        return buildozer
+
+    def test_check_configuration_tokens_happy_path(self):
+        buildozer = self._new_buildozer()
+        buildozer.check_configuration_tokens()
+
+    def test_check_configuration_tokens_collects_all_errors(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'title', '')
+        buildozer.config.set('app', 'source.dir', '')
+        buildozer.config.set('app', 'package.name', '')
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'orientation', 'sideways')
+        with mock.patch('sys.stdout', new_callable=StringIO) as out, \
+                pytest.raises(SystemExit) as ctx:
+            buildozer.check_configuration_tokens()
+        assert ctx.value.code == 1
+        output = out.getvalue()
+        assert '"title" is missing' in output
+        assert '"source.dir" is missing' in output
+        assert '"package.name" is missing' in output
+        assert '"version"' in output
+        assert 'sideways' in output
+
+    def test_check_configuration_tokens_package_name_starts_with_digit(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'package.name', '1myapp')
+        with mock.patch('sys.stdout', new_callable=StringIO) as out, \
+                pytest.raises(SystemExit):
+            buildozer.check_configuration_tokens()
+        assert 'may not start with a number' in out.getvalue()
+
+    def test_check_configuration_tokens_version_conflict(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'version.regex', r'__version__')
+        with mock.patch('sys.stdout', new_callable=StringIO) as out, \
+                pytest.raises(SystemExit):
+            buildozer.check_configuration_tokens()
+        assert (
+            'Conflict between "version" and "version.regex"' in out.getvalue()
+        )
+
+    def test_check_configuration_tokens_version_filename_missing(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'version.regex', r'__version__')
+        with mock.patch('sys.stdout', new_callable=StringIO) as out, \
+                pytest.raises(SystemExit):
+            buildozer.check_configuration_tokens()
+        assert '"version.filename" is missing' in out.getvalue()
+
+    def test_migrate_configuration_tokens_renames_deprecated(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'android.p4a_dir', '/some/path')
+        buildozer.migrate_configuration_tokens()
+        assert not buildozer.config.has_option('app', 'android.p4a_dir')
+        assert buildozer.config.get('app', 'p4a.source_dir') == '/some/path'
+
+    def test_migrate_configuration_tokens_no_app_section_noop(self):
+        buildozer = Buildozer(self.SPECFILE)
+        buildozer.migrate_configuration_tokens()
+
+    def test_check_garden_requirements_no_warning_when_unset(self):
+        buildozer = self._new_buildozer()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            buildozer.check_garden_requirements()
+        deprecations = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []
+
+    def test_check_garden_requirements_warns_when_set(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'garden_requirements', 'somelib')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            buildozer.check_garden_requirements()
+        deprecations = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert 'garden_requirements' in str(deprecations[0].message)
+
+    def test_get_version_explicit(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.get_version() == '0.1'
+
+    def test_get_version_conflict(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'version.regex', r'__version__')
+        with pytest.raises(Exception) as ctx:
+            buildozer.get_version()
+        assert 'conflict' in str(ctx.value)
+
+    def test_get_version_regex_without_filename(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'version.regex', r'__version__')
+        with pytest.raises(Exception) as ctx:
+            buildozer.get_version()
+        assert 'version.filename is missing' in str(ctx.value)
+
+    def test_get_version_filename_without_regex(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'version.filename', '/no/such/file')
+        with pytest.raises(Exception) as ctx:
+            buildozer.get_version()
+        assert 'version.regex is missing' in str(ctx.value)
+
+    def test_get_version_from_regex(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'version.filename', 'fakefile.py')
+        buildozer.config.set('app', 'version.regex', r'__version__ = "(.+)"')
+        with mock.patch(
+                'builtins.open',
+                mock.mock_open(read_data='__version__ = "1.2.3"')):
+            assert buildozer.get_version() == '1.2.3'
+
+    def test_get_version_regex_no_match(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        buildozer.config.set('app', 'version.filename', 'fakefile.py')
+        buildozer.config.set('app', 'version.regex', r'__version__ = "(.+)"')
+        with mock.patch(
+                'builtins.open',
+                mock.mock_open(read_data='nothing relevant here')), \
+                pytest.raises(Exception) as ctx:
+            buildozer.get_version()
+        assert 'Unable to find capture version' in str(ctx.value)
+
+    def test_get_version_nothing_set(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.remove_option('app', 'version')
+        with pytest.raises(Exception) as ctx:
+            buildozer.get_version()
+        assert 'Missing version or version.regex' in str(ctx.value)
+
+    def test_namify(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.namify('Hello, World!') == 'Hello__World_'
+        assert buildozer.namify('valid-name_123') == 'valid-name_123'
+
+    def test_user_build_dir_unset(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.user_build_dir is None
+
+    def test_user_build_dir_from_legacy_builddir(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.add_section('buildozer')
+        buildozer.config.set('buildozer', 'builddir', 'mybuild')
+        expected = os.path.realpath(os.path.join(
+            buildozer.root_dir, 'mybuild', '.buildozer'))
+        assert buildozer.user_build_dir == expected
+
+    def test_user_build_dir_from_modern_build_dir(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.add_section('buildozer')
+        buildozer.config.set('buildozer', 'build_dir', 'myroot')
+        expected = os.path.realpath(
+            os.path.join(buildozer.root_dir, 'myroot'))
+        assert buildozer.user_build_dir == expected
+
+    def test_buildozer_dir_default(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.buildozer_dir == os.path.join(
+            buildozer.root_dir, '.buildozer')
+
+    def test_buildozer_dir_uses_user_build_dir(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.add_section('buildozer')
+        buildozer.config.set('buildozer', 'build_dir', 'myroot')
+        assert buildozer.buildozer_dir == buildozer.user_build_dir
+
+    def test_bin_dir_default(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.bin_dir == os.path.join(buildozer.root_dir, 'bin')
+
+    def test_bin_dir_user(self):
+        buildozer = self._new_buildozer()
+        buildozer.user_bin_dir = '/custom/bin'
+        assert buildozer.bin_dir == '/custom/bin'
+
+    def test_global_packages_dir(self):
+        buildozer = self._new_buildozer()
+        buildozer.targetname = 'android'
+        assert buildozer.global_packages_dir == os.path.join(
+            os.path.expanduser('~'), '.buildozer', 'android', 'packages')
+
+    def test_package_full_name_with_domain(self):
+        buildozer = self._new_buildozer()
+        buildozer.config.set('app', 'package.domain', 'org.example')
+        assert buildozer.package_full_name == 'org.example.testapp'
+
+    def test_package_full_name_no_domain(self):
+        buildozer = self._new_buildozer()
+        assert buildozer.package_full_name == 'testapp'
+
+
 class TestCopyApplicationSources(unittest.TestCase):
     """Tests for the _copy_application_sources method."""
 
@@ -333,15 +556,13 @@ class TestCopyApplicationSources(unittest.TestCase):
         copy_calls = mock_buildops.file_copy.call_args_list
         copied_files = [call[0][0] for call in copy_calls]
 
-        self.assertTrue(any('main.py' in f for f in copied_files))
-        self.assertTrue(any('visible' in f and 'code.py' in f
-                            for f in copied_files))
-        self.assertTrue(any('subdir' in f and 'code2.py' in f
-                            for f in copied_files))
-        self.assertFalse(any('.hidden' in f for f in copied_files))
-        self.assertFalse(any('secret.py' in f for f in copied_files))
-        self.assertFalse(any('.hidden_file.py' in f for f in copied_files))
-        self.assertFalse(any('.hidden2.py' in f for f in copied_files))
+        assert any('main.py' in f for f in copied_files)
+        assert any('visible' in f and 'code.py' in f for f in copied_files)
+        assert any('subdir' in f and 'code2.py' in f for f in copied_files)
+        assert not any('.hidden' in f for f in copied_files)
+        assert not any('secret.py' in f for f in copied_files)
+        assert not any('.hidden_file.py' in f for f in copied_files)
+        assert not any('.hidden2.py' in f for f in copied_files)
 
     @mock.patch('buildozer.buildops')
     def test_source_dir_with_hidden_parent(self, mock_buildops):
@@ -377,10 +598,10 @@ class TestCopyApplicationSources(unittest.TestCase):
         copied_files = [call[0][0] for call in copy_calls]
 
         # main.py should be copied (not in a hidden dir relative to source)
-        self.assertTrue(any('main.py' in f for f in copied_files))
+        assert any('main.py' in f for f in copied_files)
         # .sub_hidden/secret.py should NOT be copied
         # (hidden relative to source)
-        self.assertFalse(any('.sub_hidden' in f for f in copied_files))
+        assert not any('.sub_hidden' in f for f in copied_files)
 
     @mock.patch('buildozer.buildops')
     def test_include_extensions_filter(self, mock_buildops):
@@ -400,9 +621,9 @@ class TestCopyApplicationSources(unittest.TestCase):
         copy_calls = mock_buildops.file_copy.call_args_list
         copied_files = [call[0][0] for call in copy_calls]
 
-        self.assertTrue(any('main.py' in f for f in copied_files))
-        self.assertTrue(any('image.png' in f for f in copied_files))
-        self.assertFalse(any('doc.txt' in f for f in copied_files))
+        assert any('main.py' in f for f in copied_files)
+        assert any('image.png' in f for f in copied_files)
+        assert not any('doc.txt' in f for f in copied_files)
 
     @mock.patch('buildozer.buildops')
     def test_exclude_dirs_filter(self, mock_buildops):
@@ -423,11 +644,10 @@ class TestCopyApplicationSources(unittest.TestCase):
         copy_calls = mock_buildops.file_copy.call_args_list
         copied_files = [call[0][0] for call in copy_calls]
 
-        self.assertTrue(any('main.py' in f for f in copied_files))
-        self.assertTrue(any('src' in f and 'code.py' in f
-                            for f in copied_files))
-        self.assertFalse(any('tests' in f for f in copied_files))
-        self.assertFalse(any('venv' in f for f in copied_files))
+        assert any('main.py' in f for f in copied_files)
+        assert any('src' in f and 'code.py' in f for f in copied_files)
+        assert not any('tests' in f for f in copied_files)
+        assert not any('venv' in f for f in copied_files)
 
     @mock.patch('buildozer.buildops')
     def test_exclude_patterns(self, mock_buildops):
@@ -448,7 +668,7 @@ class TestCopyApplicationSources(unittest.TestCase):
         copy_calls = mock_buildops.file_copy.call_args_list
         copied_files = [call[0][0] for call in copy_calls]
 
-        self.assertTrue(any('main.py' in f for f in copied_files))
-        self.assertTrue(any('icon.png' in f for f in copied_files))
-        self.assertFalse(any('LICENSE' in f for f in copied_files))
-        self.assertFalse(any('photo.jpg' in f for f in copied_files))
+        assert any('main.py' in f for f in copied_files)
+        assert any('icon.png' in f for f in copied_files)
+        assert not any('LICENSE' in f for f in copied_files)
+        assert not any('photo.jpg' in f for f in copied_files)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,426 @@
+import os
+from unittest import mock
+
+import pytest
+
+from buildozer.target import Target, no_config
+from tests.targets.utils import (
+    patch_buildops_cmd,
+    patch_buildops_file_exists,
+    patch_logger_error,
+)
+
+
+STANDARD_CMDS = (
+    'distclean', 'update', 'debug', 'release', 'deploy', 'run', 'serve',
+)
+
+DOMAIN_CASES = [
+    ('org.test', 'BUILDOZER_ALLOW_ORG_TEST_DOMAIN'),
+    ('org.kivy', 'BUILDOZER_ALLOW_KIVY_ORG_DOMAIN'),
+]
+
+
+def _make_target(standard_cmds=STANDARD_CMDS, **buildozer_attrs):
+    m_buildozer = mock.Mock(standard_cmds=standard_cmds, **buildozer_attrs)
+    return Target(m_buildozer)
+
+
+class TestNoConfigDecorator:
+
+    def test_no_config_sets_marker(self):
+        @no_config
+        def fn():
+            pass
+        assert getattr(fn, '__no_config')
+
+
+class TestTargetInit:
+
+    def test_init_defaults(self):
+        m_buildozer = mock.Mock()
+        target = Target(m_buildozer)
+        assert target.buildozer is m_buildozer
+        assert target.build_mode == 'debug'
+        assert not target.platform_update
+
+
+class TestTargetNoops:
+
+    def test_check_requirements_is_noop(self):
+        assert _make_target().check_requirements() is None
+
+    def test_compile_platform_is_noop(self):
+        assert _make_target().compile_platform() is None
+
+    def test_install_platform_is_noop(self):
+        assert _make_target().install_platform() is None
+
+    def test_get_available_packages(self):
+        assert _make_target().get_available_packages() == ['kivy']
+
+
+class TestCheckConfigurationTokens:
+
+    def test_no_errors_is_noop(self):
+        _make_target().check_configuration_tokens()
+        _make_target().check_configuration_tokens(errors=[])
+
+    def test_errors_exit_one(self):
+        target = _make_target()
+        with patch_logger_error(), \
+                mock.patch('builtins.print') as m_print, \
+                pytest.raises(SystemExit) as ctx:
+            target.check_configuration_tokens(errors=['oops', 'broken'])
+        assert ctx.value.code == 1
+        printed = [c.args[0] for c in m_print.call_args_list]
+        assert 'oops' in printed
+        assert 'broken' in printed
+
+
+class TestGetCustomCommands:
+
+    def test_filters_standard_cmds(self):
+        target = _make_target(standard_cmds=STANDARD_CMDS)
+        names = {name for name, _doc in target.get_custom_commands()}
+        assert names == {'clean'}
+
+    def test_no_standard_cmds_returns_all(self):
+        target = _make_target(standard_cmds=())
+        names = {name for name, _doc in target.get_custom_commands()}
+        assert names == {
+            'clean', 'update', 'debug', 'release', 'deploy', 'run', 'serve',
+        }
+
+
+class TestRunCommands:
+
+    def test_empty_args_exits_one(self):
+        target = _make_target()
+        with patch_logger_error(), pytest.raises(SystemExit) as ctx:
+            target.run_commands([])
+        assert ctx.value.code == 1
+        target.buildozer.usage.assert_called_once_with()
+
+    def test_unknown_command_exits_one(self):
+        target = _make_target()
+        with patch_logger_error(), pytest.raises(SystemExit) as ctx:
+            target.run_commands(['nope'])
+        assert ctx.value.code == 1
+
+    def test_flag_without_command_exits_one(self):
+        target = _make_target()
+        with patch_logger_error(), pytest.raises(SystemExit) as ctx:
+            target.run_commands(['--verbose'])
+        assert ctx.value.code == 1
+        target.buildozer.usage.assert_called_once_with()
+
+    def test_dispatches_to_cmd_method(self):
+        target = _make_target()
+        with mock.patch.object(target, 'cmd_debug', autospec=True) as m_debug:
+            target.run_commands(['debug'])
+        m_debug.assert_called_once_with([])
+
+    def test_passes_flags_to_cmd(self):
+        target = _make_target()
+        with mock.patch.object(target, 'cmd_debug', autospec=True) as m_debug:
+            target.run_commands(['debug', '--verbose'])
+        m_debug.assert_called_once_with(['--verbose'])
+
+    def test_double_dash_appends_trailing_args(self):
+        target = _make_target()
+        with mock.patch.object(target, 'cmd_debug', autospec=True) as m_debug:
+            target.run_commands(['debug', '--', 'extra1', 'extra2'])
+        m_debug.assert_called_once_with(['extra1', 'extra2'])
+
+    def test_runs_config_check_once(self):
+        target = _make_target()
+        with mock.patch.object(target, 'cmd_debug', autospec=True), \
+                mock.patch.object(target, 'cmd_run', autospec=True), \
+                mock.patch.object(
+                    target, 'check_configuration_tokens') as m_check:
+            target.run_commands(['debug', 'run'])
+        m_check.assert_called_once_with()
+
+    def test_no_config_method_skips_check(self):
+        @no_config
+        def cmd_skip(args):
+            pass
+        target = _make_target()
+        target.cmd_skip = cmd_skip
+        with mock.patch.object(
+                target, 'check_configuration_tokens') as m_check:
+            target.run_commands(['skip'])
+        m_check.assert_not_called()
+
+
+class TestCmdDelegations:
+
+    def test_cmd_clean(self):
+        target = _make_target()
+        target.cmd_clean()
+        target.buildozer.clean_platform.assert_called_once_with()
+
+    def test_cmd_update(self):
+        target = _make_target()
+        target.cmd_update()
+        assert target.platform_update
+        target.buildozer.prepare_for_build.assert_called_once_with()
+
+    def test_cmd_debug(self):
+        target = _make_target()
+        target.cmd_debug()
+        target.buildozer.prepare_for_build.assert_called_once_with()
+        assert target.build_mode == 'debug'
+        target.buildozer.build.assert_called_once_with()
+
+    def test_cmd_deploy(self):
+        target = _make_target()
+        target.cmd_deploy()
+        target.buildozer.prepare_for_build.assert_called_once_with()
+
+    def test_cmd_run(self):
+        target = _make_target()
+        target.cmd_run()
+        target.buildozer.prepare_for_build.assert_called_once_with()
+
+    def test_cmd_serve(self):
+        target = _make_target()
+        target.cmd_serve()
+        target.buildozer.cmd_serve.assert_called_once_with()
+
+
+class TestCmdRelease:
+
+    def _target_with_domain(self, domain):
+        target = _make_target()
+        target.buildozer.config.get.return_value = domain
+        return target
+
+    def test_happy_path(self):
+        target = self._target_with_domain('com.example')
+        target.cmd_release()
+        target.buildozer.prepare_for_build.assert_called_once_with()
+        assert target.build_mode == 'release'
+        target.buildozer.build.assert_called_once_with()
+
+
+class TestCheckPackageDomain:
+
+    def _target_with_domain(self, domain):
+        target = _make_target()
+        target.buildozer.config.get.return_value = domain
+        return target
+
+    @pytest.mark.parametrize('domain,env_var', DOMAIN_CASES)
+    def test_exits_without_override(self, domain, env_var):
+        target = self._target_with_domain(domain)
+        with patch_logger_error(), \
+                mock.patch.dict(os.environ, {}, clear=True), \
+                pytest.raises(SystemExit) as ctx:
+            target._check_package_domain(domain, env_var, ['msg'])
+        assert ctx.value.code == 1
+
+    @pytest.mark.parametrize('domain,env_var', DOMAIN_CASES)
+    def test_passes_with_override(self, domain, env_var):
+        target = self._target_with_domain(domain)
+        with patch_logger_error(), \
+                mock.patch.dict(os.environ, {env_var: '1'}):
+            target._check_package_domain(domain, env_var, ['msg'])
+
+    def test_noop_when_domain_differs(self):
+        target = self._target_with_domain('com.example')
+        with patch_logger_error() as m_error:
+            target._check_package_domain(
+                'org.test', 'BUILDOZER_ALLOW_ORG_TEST_DOMAIN', ['msg'])
+        m_error.assert_not_called()
+
+    def test_body_lines_are_logged(self):
+        target = self._target_with_domain('org.test')
+        with patch_logger_error() as m_error, \
+                mock.patch.dict(os.environ, {}, clear=True), \
+                pytest.raises(SystemExit):
+            target._check_package_domain(
+                'org.test',
+                'BUILDOZER_ALLOW_ORG_TEST_DOMAIN',
+                ['first line', 'second line'],
+            )
+        logged = [c.args[0] for c in m_error.call_args_list]
+        assert 'first line' in logged
+        assert 'second line' in logged
+
+
+class TestPathOrGitUrl:
+
+    def _target(self, overrides=None):
+        overrides = overrides or {}
+        target = _make_target(root_dir='/root')
+
+        def fake_getdefault(section, key, default=None):
+            return overrides.get(key, default)
+
+        target.buildozer.config.getdefault.side_effect = fake_getdefault
+        return target
+
+    def test_custom_dir_short_circuits(self):
+        target = self._target({'python_for_android_dir': 'mycheckout'})
+        path, url, branch = target.path_or_git_url('python-for-android')
+        assert path == os.path.join('/root', 'mycheckout')
+        assert url is None
+        assert branch is None
+
+    def test_default_url_and_branch(self):
+        target = self._target()
+        path, url, branch = target.path_or_git_url('python-for-android')
+        assert path is None
+        assert branch == 'master'
+        assert url == 'https://github.com/kivy/python-for-android.git'
+
+    def test_squash_hyphen_default(self):
+        target = self._target()
+        target.path_or_git_url('python-for-android')
+        keys = [
+            call.args[1]
+            for call in target.buildozer.config.getdefault.call_args_list
+        ]
+        assert 'python_for_android_dir' in keys
+        assert 'python_for_android_branch' in keys
+        assert 'python_for_android_url' in keys
+
+    def test_no_squash_hyphen(self):
+        target = self._target()
+        target.path_or_git_url('python-for-android', squash_hyphen=False)
+        keys = [
+            call.args[1]
+            for call in target.buildozer.config.getdefault.call_args_list
+        ]
+        assert 'python-for-android_dir' in keys
+
+    def test_platform_prefix(self):
+        target = self._target()
+        target.path_or_git_url('p4a', platform='android')
+        keys = [
+            call.args[1]
+            for call in target.buildozer.config.getdefault.call_args_list
+        ]
+        assert 'android.p4a_dir' in keys
+        assert 'android.p4a_branch' in keys
+        assert 'android.p4a_url' in keys
+
+    def test_url_overrides_default(self):
+        target = self._target({
+            'p4a_branch': 'develop',
+            'p4a_url': 'https://example.com/fork.git',
+        })
+        path, url, branch = target.path_or_git_url('p4a')
+        assert path is None
+        assert branch == 'develop'
+        assert url == 'https://example.com/fork.git'
+
+
+class TestInstallOrUpdateRepo:
+
+    def _target(self):
+        target = _make_target(
+            platform_dir='/platform',
+            root_dir='/root',
+            environ={'PATH': '/bin'},
+        )
+        return target
+
+    def _patch_path_or_git_url(self, target, return_value):
+        return mock.patch.object(
+            target, 'path_or_git_url', return_value=return_value)
+
+    def test_new_install_with_custom_dir(self):
+        target = self._target()
+        with self._patch_path_or_git_url(target, ('/custom', None, None)), \
+                patch_buildops_file_exists() as m_exists, \
+                mock.patch('buildozer.buildops.mkdir') as m_mkdir, \
+                mock.patch(
+                    'buildozer.buildops.file_copytree') as m_copytree, \
+                patch_buildops_cmd() as m_cmd:
+            m_exists.return_value = False
+            install_dir = target.install_or_update_repo('p4a')
+        assert install_dir == os.path.join('/platform', 'p4a')
+        m_mkdir.assert_called_once_with(install_dir)
+        m_copytree.assert_called_once_with('/custom', install_dir)
+        m_cmd.assert_not_called()
+
+    def test_new_install_without_custom_dir_clones(self):
+        target = self._target()
+        with self._patch_path_or_git_url(
+                target,
+                (None, 'https://example.com/p4a.git', 'main')), \
+                patch_buildops_file_exists() as m_exists, \
+                mock.patch('buildozer.buildops.mkdir') as m_mkdir, \
+                mock.patch(
+                    'buildozer.buildops.file_copytree') as m_copytree, \
+                patch_buildops_cmd() as m_cmd:
+            m_exists.return_value = False
+            target.install_or_update_repo('p4a')
+        m_mkdir.assert_not_called()
+        m_copytree.assert_not_called()
+        m_cmd.assert_called_once_with(
+            ['git', 'clone', '--branch', 'main',
+             'https://example.com/p4a.git'],
+            cwd='/platform',
+            env={'PATH': '/bin'},
+        )
+
+    def test_existing_install_without_update_is_noop(self):
+        target = self._target()
+        target.platform_update = False
+        with self._patch_path_or_git_url(
+                target,
+                (None, 'https://example.com/p4a.git', 'main')), \
+                patch_buildops_file_exists() as m_exists, \
+                mock.patch('buildozer.buildops.mkdir') as m_mkdir, \
+                mock.patch(
+                    'buildozer.buildops.file_copytree') as m_copytree, \
+                patch_buildops_cmd() as m_cmd:
+            m_exists.return_value = True
+            target.install_or_update_repo('p4a')
+        m_mkdir.assert_not_called()
+        m_copytree.assert_not_called()
+        m_cmd.assert_not_called()
+
+    def test_existing_install_update_with_custom_dir_copies(self):
+        target = self._target()
+        target.platform_update = True
+        with self._patch_path_or_git_url(target, ('/custom', None, None)), \
+                patch_buildops_file_exists() as m_exists, \
+                mock.patch(
+                    'buildozer.buildops.file_copytree') as m_copytree, \
+                patch_buildops_cmd() as m_cmd:
+            m_exists.return_value = True
+            target.install_or_update_repo('p4a')
+        install_dir = os.path.join('/platform', 'p4a')
+        m_copytree.assert_called_once_with('/custom', install_dir)
+        m_cmd.assert_not_called()
+
+    def test_existing_install_update_without_custom_dir_pulls(self):
+        target = self._target()
+        target.platform_update = True
+        with self._patch_path_or_git_url(
+                target,
+                (None, 'https://example.com/p4a.git', 'main')), \
+                patch_buildops_file_exists() as m_exists, \
+                mock.patch(
+                    'buildozer.buildops.file_copytree') as m_copytree, \
+                patch_buildops_cmd() as m_cmd:
+            m_exists.return_value = True
+            target.install_or_update_repo('p4a')
+        install_dir = os.path.join('/platform', 'p4a')
+        m_copytree.assert_not_called()
+        assert m_cmd.call_count == 2
+        m_cmd.assert_any_call(
+            ['git', 'clean', '-dxf'],
+            cwd=install_dir,
+            env={'PATH': '/bin'},
+        )
+        m_cmd.assert_any_call(
+            ['git', 'pull', 'origin', 'main'],
+            cwd=install_dir,
+            env={'PATH': '/bin'},
+        )


### PR DESCRIPTION
Also extract _check_package_domain helper from cmd_release to dedupe the near-identical org.test and org.kivy guard blocks, preserving the user-visible output byte-for-byte.