### PR TITLE
:fire: Drop EOL Python 3.8 and 3.9 support

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -7,8 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-           - '3.8'
-           - '3.9'
            - '3.10'
            - '3.11'
            - '3.12'

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ for installing Buildozer on Ubuntu or on MacOS, also there are special notes for
 be used (for example Colab) but there are no instructions. The iOS section 
 contains instructions for installing kivy-ios on MacOS.
 
-Buildozer is tested on Python 3.8 and above. 
+Buildozer is tested on Python 3.10 and above.
 
 Targeting Android
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -2,35 +2,16 @@
 Buildozer
 '''
 
-import sys
 from setuptools import setup
 from os.path import dirname, join
-import codecs
 import os
 import re
-import io
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 8)
-
-# This check and everything above must remain compatible with Python 2.7.
-if CURRENT_PYTHON < REQUIRED_PYTHON:
-    sys.stderr.write("""
-==========================
-Unsupported Python version
-==========================
-This version of buildozer requires Python {}.{}, but you're trying to
-install it on Python {}.{}.
-""".format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
-    sys.exit(1)
-
 
 def find_version(*file_paths):
-    # Open in Latin-1 so that we avoid encoding errors.
-    # Use codecs.open for Python 2 compatibility
-    with codecs.open(os.path.join(here, *file_paths), 'r', 'utf-8') as f:
+    with open(os.path.join(here, *file_paths), encoding='utf-8') as f:
         version_file = f.read()
 
     # The version line must have the form
@@ -43,9 +24,9 @@ def find_version(*file_paths):
 
 
 curdir = dirname(__file__)
-with io.open(join(curdir, "README.md"), encoding="utf-8") as fd:
+with open(join(curdir, "README.md"), encoding="utf-8") as fd:
     readme = fd.read()
-with io.open(join(curdir, "CHANGELOG.md"), encoding="utf-8") as fd:
+with open(join(curdir, "CHANGELOG.md"), encoding="utf-8") as fd:
     changelog = fd.read()
 
 setup(
@@ -86,14 +67,12 @@ setup(
         'docs': ['sphinx', 'sphinxawesome_theme>=5.3,<6'],
         'ios': ['kivy-ios'],
     },
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Python 3.8 reached end-of-life in October 2024 and 3.9 in October 2025, so neither receives upstream security fixes anymore. The new minimum is Python 3.10.

- Bump python_requires to >=3.10 and trim the Trove classifiers
- Drop 3.8 and 3.9 from the CI test matrix
- Update the installation doc

While the pre-install version guard is being touched, also remove the surrounding Python 2.7-compat scaffolding from setup.py (REQUIRED_PYTHON tuple, codecs.open and io.open shims); pip honors python_requires, so the runtime guard is redundant.