### PR TITLE
:bug: Preserve tar symlinks on Python 3.14

### DIFF
--- a/buildozer/buildops.py
+++ b/buildozer/buildops.py
@@ -122,8 +122,11 @@ def file_extract(archive, env, cwd="."):
         for extension in (".tgz", ".tar.gz", ".tbz2", ".tar.bz2")
     ):
         LOGGER.debug("Extracting {0} to {1}".format(archive, cwd))
+        extract_kwargs = {}
+        if hasattr(tarfile, "fully_trusted_filter"):
+            extract_kwargs["filter"] = "fully_trusted"
         with tarfile.open(path, "r") as compressed_file:
-            compressed_file.extractall(cwd)
+            compressed_file.extractall(cwd, **extract_kwargs)
         return
 
     if path.suffix == ".zip":

--- a/tests/test_buildops.py
+++ b/tests/test_buildops.py
@@ -1,4 +1,5 @@
-from os import environ, unlink
+import io
+from os import environ, readlink, unlink
 from pathlib import Path
 import tarfile
 from queue import Queue
@@ -283,6 +284,43 @@ class TestBuildOps(TestCase):
             with open(text_file_path, "r") as uncompressed_file:
                 assert uncompressed_file.read() == "Text to tgz"
             m_logger.reset_mock()
+
+    @skipIf(platform == "win32", "Symlinks require admin on Windows")
+    def test_extract_tarball_preserves_symlinks(self):
+        with mock.patch(
+            "buildozer.buildops.LOGGER"
+        ) as m_logger, TemporaryDirectory() as base_dir:
+            m_logger.log_level = 2
+            m_logger.INFO = 1
+
+            tarfile_path = Path(base_dir) / "symlinks.tgz"
+            with tarfile.open(tarfile_path, "x:gz") as outfile:
+                payload = b"target content"
+                target_info = tarfile.TarInfo("target.txt")
+                target_info.size = len(payload)
+                outfile.addfile(target_info, io.BytesIO(payload))
+
+                rel_info = tarfile.TarInfo("rel_link")
+                rel_info.type = tarfile.SYMTYPE
+                rel_info.linkname = "target.txt"
+                outfile.addfile(rel_info)
+
+                abs_info = tarfile.TarInfo("abs_link")
+                abs_info.type = tarfile.SYMTYPE
+                abs_info.linkname = "/etc/hostname"
+                outfile.addfile(abs_info)
+
+            buildops.file_extract(tarfile_path, environ, cwd=base_dir)
+
+            assert (Path(base_dir) / "target.txt").is_file()
+
+            rel_path = Path(base_dir) / "rel_link"
+            assert rel_path.is_symlink()
+            assert readlink(rel_path) == "target.txt"
+
+            abs_path = Path(base_dir) / "abs_link"
+            assert abs_path.is_symlink()
+            assert readlink(abs_path) == "/etc/hostname"
 
     def test_cmd_unicode_decode(self):
         """


### PR DESCRIPTION
Python 3.14 changes tarfile.extractall's default extraction filter to 'data' (PEP 706), which raises AbsoluteLinkError on absolute symlink entries. SDK/NDK/JDK extraction goes through buildops.file_extract; NDK r23b's macOS tarball is documented to contain absolute symlinks (android/ndk#1671), so `buildozer android debug` against that NDK version would fail on 3.14.

Pass filter='fully_trusted' to extractall on Python 3.12+ via feature detection so 3.10/3.11 (where the kwarg does not exist) keep working unchanged.

Add test_extract_tarball_preserves_symlinks which builds a tarball with relative and absolute symlinks and asserts both survive extraction. Without the filter argument the absolute-symlink assertion fails on 3.14 with tarfile.AbsoluteLinkError.