### PR TITLE
:bug: Fix iOS app display name

### DIFF
--- a/buildozer/targets/ios.py
+++ b/buildozer/targets/ios.py
@@ -236,9 +236,12 @@ class TargetIos(Target):
         plist_fn = '{}-Info.plist'.format(app_name.lower())
         plist_rfn = join(self.app_project_dir, plist_fn)
         version = self.buildozer.get_version()
+        title = self.buildozer.config.get('app', 'title')
         self.logger.info('Update Plist {}'.format(plist_fn))
         plist = self.load_plist_from_file(plist_rfn)
+        plist['CFBundleDisplayName'] = title
         plist['CFBundleIdentifier'] = self._get_package()
+        plist['CFBundleName'] = title
         plist['CFBundleShortVersionString'] = version
         plist['CFBundleVersion'] = '{}.{}'.format(version,
                 self.buildozer.build_id)

--- a/tests/targets/test_ios.py
+++ b/tests/targets/test_ios.py
@@ -217,7 +217,9 @@ class TestTargetIos:
         assert m_dump_plist_to_file.call_args_list == [
             mock.call(
                 {
+                    "CFBundleDisplayName": "My Application",
                     "CFBundleIdentifier": "org.test.myapp",
+                    "CFBundleName": "My Application",
                     "CFBundleShortVersionString": "0.1",
                     "CFBundleVersion": "0.1.None",
                 },


### PR DESCRIPTION
Set CFBundleDisplayName and CFBundleName from the Buildozer spec title when updating the generated iOS plist. Keep package.name for project paths and bundle identifiers.

Fixes #1976