### PR TITLE
fix: Remove `cython` from `install_requirements`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,6 @@ setup(
     install_requires=[
         'pexpect',
         'packaging',
-        # Cython is required by both kivy-ios and python-for-android.
-        # However, python-for-android does not include it in its dependencies
-        # and kivy-ios's dependencies are not always checked, so it is included
-        # here.
-        # Restricted version because python-for-android's recipes can't handle
-        # later versions.
-        'cython<3.0'
     ],
     extras_require={
         'test': ['pytest'],


### PR DESCRIPTION
This project does not require `cython` to run from my understanding.

But since it is included as a runtime dependency, `pip check` fails on it:

```
% pip check
buildozer 1.5.1.dev0 requires cython, which is not installed.
```

This PR thus removes it from the deps.

To address the removed comment - if a downstream project still requires cython to be installed as a runtime dependency, add a runtime dependency to the downstream project instead of implementing workarounds elsewhere.

If kivy-ios still requires cython, it's missing in https://github.com/kivy/kivy-ios/blob/892c4b72ee4eb3537310b0694d5fb73cb6a18d53/requirements.txt

If python-4-android still requires cython, it's missing in https://github.com/kivy/python-for-android/blob/d156b3df891b54239d039c3f5af0dc8d42117b0e/setup.py#L21-L25

The Dockerfile even tries to hack its own Cython version in(why, it's currently pulling it from the dependencies, no?), I presume that is equally wrong but wasn't sure, so this PR doesn't address it - I can tack it on if needed: https://github.com/kivy/buildozer/blob/105543da41f7a0c866a46ff07d10cb8137df2e7b/Dockerfile#L84